### PR TITLE
Use STAT_BARS colors on home progress bars

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -49,7 +49,10 @@ export default function Index() {
                   <View
                     style={[
                       styles.progressBarFill,
-                      { width: `${Math.min(stat.value * 100, 100)}%` },
+                      {
+                        width: `${Math.min(stat.value * 100, 100)}%`,
+                        backgroundColor: stat.color,
+                      },
                     ]}
                   />
                 </View>


### PR DESCRIPTION
## Summary
- apply each STAT_BARS color to its corresponding progress bar on the home screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3b291f688327958dea1ef222fbdf