### PR TITLE
Add FastAPI backend with habit tracking models

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/habit

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,21 @@
+# Habit Projects Backend
+
+Cette application backend fournit une API FastAPI connectée à une base PostgreSQL pour gérer les fonctionnalités de gamification décrites dans le MVP.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+Créez un fichier `.env` à la racine du dossier `backend/` en vous basant sur `.env.example`.
+
+## Démarrage
+
+```bash
+uvicorn app.main:app --reload
+```
+
+L'API sera accessible sur http://127.0.0.1:8000.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""Backend application package."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,5 @@
+"""API routers for the Habit Projects backend."""
+
+from .task_logs import router as task_logs_router
+
+__all__ = ["task_logs_router"]

--- a/backend/app/api/task_logs.py
+++ b/backend/app/api/task_logs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..database import get_session
+from ..schemas import TaskLogCreate, TaskLogRead
+from ..services.task_logs import TaskLogError, TaskLogNotFound, create_task_log
+
+router = APIRouter(prefix="/task-logs", tags=["task_logs"])
+
+
+def get_db_session():
+    with get_session() as session:
+        yield session
+
+
+@router.post("", response_model=TaskLogRead, status_code=status.HTTP_201_CREATED)
+def create_task_log_endpoint(
+    payload: TaskLogCreate,
+    session: Session = Depends(get_db_session),
+):
+    try:
+        task_log = create_task_log(session, payload)
+        session.refresh(task_log)
+        return task_log
+    except TaskLogNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except TaskLogError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,23 @@
+from functools import lru_cache
+from pathlib import Path
+from pydantic import BaseSettings, Field
+from dotenv import load_dotenv
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(BASE_DIR / ".env")
+
+
+class Settings(BaseSettings):
+    database_url: str = Field(..., env="DATABASE_URL")
+    app_name: str = "Habit Projects Backend"
+    timezone: str = "Europe/Paris"
+
+    class Config:
+        env_file = str(BASE_DIR / ".env")
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,26 @@
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+from .config import get_settings
+
+settings = get_settings()
+engine = create_engine(settings.database_url, pool_pre_ping=True, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, class_=Session)
+
+Base = declarative_base()
+
+
+@contextmanager
+def get_session() -> Iterator[Session]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .api.task_logs import router as task_logs_router
+from .config import get_settings
+
+settings = get_settings()
+
+app = FastAPI(title=settings.app_name)
+app.include_router(task_logs_router)
+
+
+@app.get("/health", tags=["health"])
+def healthcheck():
+    return {"status": "ok"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,431 @@
+"""SQLAlchemy models for the Habit Projects backend."""
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class TimestampMixin:
+    """Common columns for creation and update timestamps."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class SourceType(enum.Enum):
+    TASK_LOG = "task_log"
+    CHALLENGE = "challenge"
+    BONUS = "bonus"
+
+
+class SnapshotPeriod(enum.Enum):
+    DAY = "day"
+    WEEK = "week"
+
+
+class ChallengeStatus(enum.Enum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    EXPIRED = "expired"
+
+
+class User(Base, TimestampMixin):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(120), nullable=False)
+    timezone: Mapped[str] = mapped_column(String(64), nullable=False, default="Europe/Paris")
+
+    avatar: Mapped["UserAvatar"] = relationship("UserAvatar", back_populates="user", uselist=False)
+    domain_settings: Mapped[list["UserDomainSetting"]] = relationship(
+        "UserDomainSetting", back_populates="user", cascade="all, delete-orphan"
+    )
+    tasks: Mapped[list["UserTask"]] = relationship(
+        "UserTask", back_populates="user", cascade="all, delete-orphan"
+    )
+    task_logs: Mapped[list["TaskLog"]] = relationship(
+        "TaskLog", back_populates="user", cascade="all, delete-orphan"
+    )
+    xp_events: Mapped[list["XPEvent"]] = relationship(
+        "XPEvent", back_populates="user", cascade="all, delete-orphan"
+    )
+    level: Mapped["UserLevel"] = relationship(
+        "UserLevel", back_populates="user", uselist=False, cascade="all, delete-orphan"
+    )
+    streaks: Mapped[list["Streak"]] = relationship(
+        "Streak", back_populates="user", cascade="all, delete-orphan"
+    )
+    snapshots: Mapped[list["ProgressSnapshot"]] = relationship(
+        "ProgressSnapshot", back_populates="user", cascade="all, delete-orphan"
+    )
+    user_settings: Mapped["UserSettings"] = relationship(
+        "UserSettings", back_populates="user", uselist=False, cascade="all, delete-orphan"
+    )
+
+
+class Avatar(Base):
+    __tablename__ = "avatars"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    key: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    asset_url: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    users: Mapped[list["UserAvatar"]] = relationship("UserAvatar", back_populates="avatar")
+
+
+class UserAvatar(Base):
+    __tablename__ = "user_avatar"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    avatar_id: Mapped[int] = mapped_column(
+        ForeignKey("avatars.id", ondelete="RESTRICT"), nullable=False
+    )
+    color_theme: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    equipped_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User", back_populates="avatar")
+    avatar: Mapped[Avatar] = relationship("Avatar", back_populates="users")
+
+
+class Domain(Base):
+    __tablename__ = "domains"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    key: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    icon: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    order_index: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    user_settings: Mapped[list["UserDomainSetting"]] = relationship(
+        "UserDomainSetting", back_populates="domain"
+    )
+    task_templates: Mapped[list["TaskTemplate"]] = relationship(
+        "TaskTemplate", back_populates="domain"
+    )
+
+
+class UserDomainSetting(Base):
+    __tablename__ = "user_domain_settings"
+    __table_args__ = (UniqueConstraint("user_id", "domain_id", name="uq_user_domain"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    domain_id: Mapped[int] = mapped_column(
+        ForeignKey("domains.id", ondelete="CASCADE"), nullable=False
+    )
+    weekly_target_points: Mapped[int] = mapped_column(Integer, nullable=False, default=100)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    user: Mapped[User] = relationship("User", back_populates="domain_settings")
+    domain: Mapped[Domain] = relationship("Domain", back_populates="user_settings")
+
+
+class TaskTemplate(Base, TimestampMixin):
+    __tablename__ = "task_templates"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id", ondelete="CASCADE"), nullable=False)
+    default_xp: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    default_points: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    unit: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    domain: Mapped[Domain] = relationship("Domain", back_populates="task_templates")
+    user_tasks: Mapped[list["UserTask"]] = relationship("UserTask", back_populates="template")
+
+
+class UserTask(Base, TimestampMixin):
+    __tablename__ = "user_tasks"
+    __table_args__ = (
+        Index("ix_user_tasks_user_is_favorite", "user_id", "is_favorite"),
+        UniqueConstraint("user_id", "id", name="uq_user_task_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    template_id: Mapped[int | None] = mapped_column(
+        ForeignKey("task_templates.id", ondelete="SET NULL"), nullable=True
+    )
+    custom_title: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    custom_xp: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    custom_points: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id", ondelete="CASCADE"), nullable=False)
+    is_favorite: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    user: Mapped[User] = relationship("User", back_populates="tasks")
+    template: Mapped[TaskTemplate | None] = relationship("TaskTemplate", back_populates="user_tasks")
+    domain: Mapped[Domain] = relationship("Domain")
+    task_logs: Mapped[list["TaskLog"]] = relationship("TaskLog", back_populates="user_task")
+
+
+class TaskLog(Base, TimestampMixin):
+    __tablename__ = "task_logs"
+    __table_args__ = (
+        Index("ix_task_logs_user_occurred", "user_id", "occurred_at"),
+        Index("ix_task_logs_user_domain_occurred", "user_id", "domain_id", "occurred_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    user_task_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user_tasks.id", ondelete="SET NULL"), nullable=True
+    )
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id", ondelete="CASCADE"), nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    quantity: Mapped[Decimal | None] = mapped_column(Numeric(10, 2), nullable=True)
+    unit: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    xp_awarded: Mapped[int] = mapped_column(Integer, nullable=False)
+    points_awarded: Mapped[int] = mapped_column(Integer, nullable=False)
+    source: Mapped[str] = mapped_column(String(50), nullable=False, default="manual")
+
+    user: Mapped[User] = relationship("User", back_populates="task_logs")
+    user_task: Mapped[UserTask | None] = relationship("UserTask", back_populates="task_logs")
+    domain: Mapped[Domain] = relationship("Domain")
+    xp_events: Mapped[list["XPEvent"]] = relationship(
+        "XPEvent",
+        primaryjoin="TaskLog.id==XPEvent.source_id",
+        viewonly=True,
+    )
+
+
+class XPEvent(Base):
+    __tablename__ = "xp_events"
+    __table_args__ = (Index("ix_xp_events_user_occurred", "user_id", "occurred_at"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    domain_id: Mapped[int | None] = mapped_column(
+        ForeignKey("domains.id", ondelete="SET NULL"), nullable=True
+    )
+    source_type: Mapped[SourceType] = mapped_column(Enum(SourceType), nullable=False)
+    source_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    delta_xp: Mapped[int] = mapped_column(Integer, nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User", back_populates="xp_events")
+    domain: Mapped[Domain | None] = relationship("Domain")
+    task_log: Mapped[TaskLog | None] = relationship(
+        "TaskLog",
+        primaryjoin="XPEvent.source_id==TaskLog.id",
+        viewonly=True,
+    )
+
+
+class UserLevel(Base):
+    __tablename__ = "user_level"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    current_level: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    current_xp: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    xp_to_next: Mapped[int] = mapped_column(Integer, nullable=False, default=100)
+    last_update_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User", back_populates="level")
+
+
+class Streak(Base):
+    __tablename__ = "streaks"
+    __table_args__ = (UniqueConstraint("user_id", "domain_id", name="uq_streak"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    domain_id: Mapped[int] = mapped_column(
+        ForeignKey("domains.id", ondelete="CASCADE"), nullable=False
+    )
+    current_streak_days: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    best_streak_days: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_activity_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    user: Mapped[User] = relationship("User", back_populates="streaks")
+    domain: Mapped[Domain] = relationship("Domain")
+
+
+class ProgressSnapshot(Base):
+    __tablename__ = "progress_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "domain_id", "period", "period_start_date", name="uq_progress_snapshot"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    domain_id: Mapped[int] = mapped_column(
+        ForeignKey("domains.id", ondelete="CASCADE"), nullable=False
+    )
+    period: Mapped[SnapshotPeriod] = mapped_column(Enum(SnapshotPeriod), nullable=False)
+    period_start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    points_total: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    xp_total: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User", back_populates="snapshots")
+    domain: Mapped[Domain] = relationship("Domain")
+
+
+class Challenge(Base, TimestampMixin):
+    __tablename__ = "challenges"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    domain_id: Mapped[int] = mapped_column(ForeignKey("domains.id", ondelete="CASCADE"), nullable=False)
+    start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    end_date: Mapped[date] = mapped_column(Date, nullable=False)
+    target_points: Mapped[int] = mapped_column(Integer, nullable=False)
+    xp_reward: Mapped[int] = mapped_column(Integer, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    domain: Mapped[Domain] = relationship("Domain")
+    participants: Mapped[list["UserChallenge"]] = relationship(
+        "UserChallenge", back_populates="challenge", cascade="all, delete-orphan"
+    )
+
+
+class UserChallenge(Base):
+    __tablename__ = "user_challenges"
+    __table_args__ = (UniqueConstraint("user_id", "challenge_id", name="uq_user_challenge"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    challenge_id: Mapped[int] = mapped_column(
+        ForeignKey("challenges.id", ondelete="CASCADE"), nullable=False
+    )
+    progress_points: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    status: Mapped[ChallengeStatus] = mapped_column(
+        Enum(ChallengeStatus), nullable=False, default=ChallengeStatus.ACTIVE
+    )
+
+    user: Mapped[User] = relationship("User")
+    challenge: Mapped[Challenge] = relationship("Challenge", back_populates="participants")
+
+
+class Reward(Base, TimestampMixin):
+    __tablename__ = "rewards"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    cost_xp: Mapped[int] = mapped_column(Integer, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    user_rewards: Mapped[list["UserReward"]] = relationship("UserReward", back_populates="reward")
+
+
+class UserReward(Base):
+    __tablename__ = "user_rewards"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    reward_id: Mapped[int] = mapped_column(
+        ForeignKey("rewards.id", ondelete="CASCADE"), nullable=False
+    )
+    acquired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User")
+    reward: Mapped[Reward] = relationship("Reward", back_populates="user_rewards")
+
+
+class UserSettings(Base):
+    __tablename__ = "user_settings"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    language: Mapped[str] = mapped_column(String(10), nullable=False, default="fr")
+    notifications_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    first_day_of_week: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    user: Mapped[User] = relationship("User", back_populates="user_settings")
+
+
+class Consent(Base):
+    __tablename__ = "consents"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
+    version: Mapped[str] = mapped_column(String(50), nullable=False)
+    accepted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import datetime, date
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from .models import ChallengeStatus, SnapshotPeriod, SourceType
+
+
+class DomainBase(BaseModel):
+    id: int
+    key: str
+    name: str
+    icon: Optional[str]
+    order_index: int
+
+    class Config:
+        orm_mode = True
+
+
+class TaskLogCreate(BaseModel):
+    user_id: UUID
+    user_task_id: Optional[UUID] = None
+    domain_id: Optional[int] = None
+    occurred_at: Optional[datetime] = None
+    quantity: Optional[Decimal] = None
+    unit: Optional[str] = None
+    notes: Optional[str] = None
+    source: str = Field(default="manual")
+
+
+class TaskLogRead(BaseModel):
+    id: UUID
+    user_id: UUID
+    user_task_id: Optional[UUID]
+    domain_id: int
+    occurred_at: datetime
+    quantity: Optional[Decimal]
+    unit: Optional[str]
+    notes: Optional[str]
+    xp_awarded: int
+    points_awarded: int
+    source: str
+
+    class Config:
+        orm_mode = True
+
+
+class XPEventRead(BaseModel):
+    id: UUID
+    user_id: UUID
+    domain_id: Optional[int]
+    source_type: SourceType
+    source_id: Optional[UUID]
+    delta_xp: int
+    occurred_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class UserLevelRead(BaseModel):
+    user_id: UUID
+    current_level: int
+    current_xp: int
+    xp_to_next: int
+    last_update_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ProgressSnapshotRead(BaseModel):
+    id: UUID
+    user_id: UUID
+    domain_id: int
+    period: SnapshotPeriod
+    period_start_date: date
+    points_total: int
+    xp_total: int
+    computed_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class StreakRead(BaseModel):
+    id: int
+    user_id: UUID
+    domain_id: int
+    current_streak_days: int
+    best_streak_days: int
+    last_activity_date: Optional[date]
+
+    class Config:
+        orm_mode = True
+
+
+class ChallengeRead(BaseModel):
+    id: int
+    title: str
+    domain_id: int
+    start_date: date
+    end_date: date
+    target_points: int
+    xp_reward: int
+    is_active: bool
+
+    class Config:
+        orm_mode = True
+
+
+class UserChallengeRead(BaseModel):
+    id: int
+    user_id: UUID
+    challenge_id: int
+    progress_points: int
+    status: ChallengeStatus
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for business rules."""

--- a/backend/app/services/task_logs.py
+++ b/backend/app/services/task_logs.py
@@ -1,0 +1,267 @@
+"""Business logic for task log creation and related side effects."""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..models import (
+    Domain,
+    ProgressSnapshot,
+    SnapshotPeriod,
+    SourceType,
+    Streak,
+    TaskLog,
+    User,
+    UserLevel,
+    UserTask,
+    XPEvent,
+)
+from ..schemas import TaskLogCreate
+
+
+class TaskLogError(Exception):
+    """Base exception for task log operations."""
+
+
+class TaskLogNotFound(TaskLogError):
+    """Raised when a required entity is missing."""
+
+
+def xp_to_next(level: int) -> int:
+    """Return the amount of XP required to reach the next level."""
+
+    return 100 + max(level - 1, 0) * 25
+
+
+def get_user_task(session: Session, user_task_id: UUID, user_id: UUID) -> UserTask:
+    stmt = select(UserTask).where(
+        UserTask.id == user_task_id,
+        UserTask.user_id == user_id,
+        UserTask.is_active.is_(True),
+    )
+    user_task = session.execute(stmt).scalar_one_or_none()
+    if not user_task:
+        raise TaskLogNotFound("User task introuvable ou inactif.")
+    return user_task
+
+
+def resolve_domain(session: Session, domain_id: Optional[int]) -> Domain:
+    if domain_id is None:
+        raise TaskLogError("Un domain_id doit être spécifié.")
+    domain = session.get(Domain, domain_id)
+    if not domain:
+        raise TaskLogNotFound("Domaine introuvable.")
+    return domain
+
+
+def resolve_rewards(
+    user_task: Optional[UserTask],
+    quantity: Optional[Decimal],
+) -> tuple[int, int, Optional[str]]:
+    base_xp = None
+    base_points = None
+    unit: Optional[str] = None
+
+    if user_task:
+        base_xp = user_task.custom_xp
+        base_points = user_task.custom_points
+        if user_task.template:
+            if base_xp is None:
+                base_xp = user_task.template.default_xp
+            if base_points is None:
+                base_points = user_task.template.default_points
+            unit = user_task.template.unit
+    if base_xp is None:
+        base_xp = 0
+    if base_points is None:
+        base_points = 0
+
+    multiplier = Decimal(quantity) if quantity is not None else Decimal(1)
+    xp_awarded = int(multiplier * Decimal(base_xp)) if base_xp else 0
+    points_awarded = int(multiplier * Decimal(base_points)) if base_points else 0
+
+    return xp_awarded, points_awarded, unit
+
+
+def ensure_user_exists(session: Session, user_id: UUID) -> User:
+    user = session.get(User, user_id)
+    if not user:
+        raise TaskLogNotFound("Utilisateur introuvable.")
+    return user
+
+
+def get_or_create_level(session: Session, user: User) -> UserLevel:
+    level = session.get(UserLevel, user.id)
+    if not level:
+        level = UserLevel(user_id=user.id, current_level=1, current_xp=0, xp_to_next=xp_to_next(1))
+        session.add(level)
+        session.flush()
+    return level
+
+
+def update_level(level: UserLevel, xp_awarded: int, occurred_at: datetime) -> None:
+    level.current_xp += xp_awarded
+    leveled_up = False
+    while level.current_xp >= level.xp_to_next:
+        level.current_xp -= level.xp_to_next
+        level.current_level += 1
+        level.xp_to_next = xp_to_next(level.current_level)
+        leveled_up = True
+    if leveled_up or xp_awarded:
+        level.last_update_at = occurred_at
+
+
+def update_streak(session: Session, user_id: UUID, domain_id: int, occurred_date: date) -> Streak:
+    stmt = select(Streak).where(Streak.user_id == user_id, Streak.domain_id == domain_id)
+    streak = session.execute(stmt).scalar_one_or_none()
+    if not streak:
+        streak = Streak(
+            user_id=user_id,
+            domain_id=domain_id,
+            current_streak_days=0,
+            best_streak_days=0,
+            last_activity_date=None,
+        )
+        session.add(streak)
+        session.flush()
+
+    if streak.last_activity_date == occurred_date:
+        pass
+    elif streak.last_activity_date and occurred_date == streak.last_activity_date + timedelta(days=1):
+        streak.current_streak_days += 1
+        streak.last_activity_date = occurred_date
+    else:
+        streak.current_streak_days = 1
+        streak.last_activity_date = occurred_date
+
+    if streak.current_streak_days > streak.best_streak_days:
+        streak.best_streak_days = streak.current_streak_days
+
+    return streak
+
+
+def update_snapshot(
+    session: Session,
+    user_id: UUID,
+    domain_id: int,
+    period: SnapshotPeriod,
+    start_date: date,
+    xp_awarded: int,
+    points_awarded: int,
+    occurred_at: datetime,
+) -> ProgressSnapshot:
+    stmt = select(ProgressSnapshot).where(
+        ProgressSnapshot.user_id == user_id,
+        ProgressSnapshot.domain_id == domain_id,
+        ProgressSnapshot.period == period,
+        ProgressSnapshot.period_start_date == start_date,
+    )
+    snapshot = session.execute(stmt).scalar_one_or_none()
+    if not snapshot:
+        snapshot = ProgressSnapshot(
+            user_id=user_id,
+            domain_id=domain_id,
+            period=period,
+            period_start_date=start_date,
+            points_total=0,
+            xp_total=0,
+        )
+        session.add(snapshot)
+        session.flush()
+
+    snapshot.points_total += points_awarded
+    snapshot.xp_total += xp_awarded
+    snapshot.computed_at = occurred_at
+    return snapshot
+
+
+def monday_start(date_value: date) -> date:
+    return date_value - timedelta(days=date_value.weekday())
+
+
+def create_task_log(session: Session, payload: TaskLogCreate) -> TaskLog:
+    """Create a task log following MVP rules."""
+
+    user = ensure_user_exists(session, payload.user_id)
+
+    user_task: Optional[UserTask] = None
+    domain_id: Optional[int] = payload.domain_id
+
+    if payload.user_task_id:
+        user_task = get_user_task(session, payload.user_task_id, payload.user_id)
+        domain_id = user_task.domain_id
+
+    if domain_id is None:
+        raise TaskLogError("Impossible de déterminer le domaine de la tâche.")
+
+    resolve_domain(session, domain_id)
+
+    xp_awarded, points_awarded, default_unit = resolve_rewards(user_task, payload.quantity)
+    unit = payload.unit or default_unit
+    if payload.occurred_at:
+        occurred_at = payload.occurred_at
+        if occurred_at.tzinfo is None:
+            occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+        else:
+            occurred_at = occurred_at.astimezone(timezone.utc)
+    else:
+        occurred_at = datetime.now(timezone.utc)
+
+    task_log = TaskLog(
+        user_id=payload.user_id,
+        user_task_id=payload.user_task_id,
+        domain_id=domain_id,
+        occurred_at=occurred_at,
+        quantity=payload.quantity,
+        unit=unit,
+        notes=payload.notes,
+        xp_awarded=xp_awarded,
+        points_awarded=points_awarded,
+        source=payload.source,
+    )
+    session.add(task_log)
+    session.flush()
+
+    xp_event = XPEvent(
+        user_id=payload.user_id,
+        domain_id=domain_id,
+        source_type=SourceType.TASK_LOG,
+        source_id=task_log.id,
+        delta_xp=xp_awarded,
+        occurred_at=occurred_at,
+    )
+    session.add(xp_event)
+
+    level = get_or_create_level(session, user)
+    update_level(level, xp_awarded, occurred_at)
+
+    occurred_date = occurred_at.astimezone(timezone.utc).date()
+    update_streak(session, payload.user_id, domain_id, occurred_date)
+
+    update_snapshot(
+        session,
+        payload.user_id,
+        domain_id,
+        SnapshotPeriod.DAY,
+        occurred_date,
+        xp_awarded,
+        points_awarded,
+        occurred_at,
+    )
+    update_snapshot(
+        session,
+        payload.user_id,
+        domain_id,
+        SnapshotPeriod.WEEK,
+        monday_start(occurred_date),
+        xp_awarded,
+        points_awarded,
+        occurred_at,
+    )
+
+    return task_log

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+SQLAlchemy==2.0.25
+psycopg[binary]==3.1.18
+pydantic==1.10.13
+python-dotenv==1.0.1
+alembic==1.13.1


### PR DESCRIPTION
## Summary
- introduce a new FastAPI backend package configured for PostgreSQL and environment-based settings
- implement full SQLAlchemy data model covering users, tasks, progress tracking, streaks, levels, challenges, and rewards
- add task log service and API endpoint that applies MVP rules for XP, streak, and snapshot updates

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68de4620be688327814005b07c880ac0