### PR TITLE
fix: update SQLAlchemy for Python 3.13 compatibility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.1
-SQLAlchemy==2.0.36
+SQLAlchemy==2.0.39
 psycopg[binary]==3.2.10
 pydantic==1.10.13
 python-dotenv==1.0.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.27.1
-SQLAlchemy==2.0.25
+SQLAlchemy==2.0.36
 psycopg[binary]==3.2.10
 pydantic==1.10.13
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- bump SQLAlchemy to version 2.0.36 to restore compatibility with Python 3.13

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5d89834883279601fd43e9a64141