### PR TITLE
Connect frontend to backend data

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,15 @@
 import { Stack } from "expo-router";
 
+import { HabitDataProvider } from "../context/HabitDataContext";
+
 export default function RootLayout() {
-  return <Stack
-    screenOptions={{
-      headerShown: false,
-    }}
-  />;
+  return (
+    <HabitDataProvider>
+      <Stack
+        screenOptions={{
+          headerShown: false,
+        }}
+      />
+    </HabitDataProvider>
+  );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,8 @@
 import { useRouter } from "expo-router";
+import { Feather } from "@expo/vector-icons";
 import {
+  ActivityIndicator,
+  RefreshControl,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -7,20 +10,119 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { Feather } from "@expo/vector-icons";
-import BottomNav from "../components/BottomNav";
 
-const STAT_BARS = [
-  { label: "Santé", value: 0.8, color: "#10b981", icon: '⚡' },
-  { label: "Énergie", value: 0.65, color: "#2ea043", icon: '🔋' },
-  { label: "Discipline", value: 0.72, color: "#3b82f6", icon: '🛡️' },
-  { label: "Finances", value: 0.4, color: "#f59e0b", icon: '💰' },
-  { label: "Relations", value: 0.55, color: "#ec4899", icon: '👥' },
-  { label: "Bien-être", value: 0.9, color: "#8b5cf6", icon: '🧘' },
-];
+import BottomNav from "../components/BottomNav";
+import { useHabitData } from "../context/HabitDataContext";
+
+const DOMAIN_COLORS: Record<string, string> = {
+  health: "#10b981",
+  finance: "#f59e0b",
+  work: "#3b82f6",
+  relations: "#ec4899",
+  wellness: "#8b5cf6",
+};
 
 export default function Index() {
   const router = useRouter();
+  const {
+    state: { status, dashboard, errorMessage },
+    refresh,
+    isRefreshing,
+  } = useHabitData();
+
+  const renderContent = () => {
+    if ((status === "loading" || status === "idle") && !dashboard) {
+      return (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#58a6ff" />
+          <Text style={styles.loadingLabel}>Chargement de votre tableau de bord…</Text>
+        </View>
+      );
+    }
+
+    if (status === "error" && !dashboard) {
+      return (
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorLabel}>{errorMessage ?? "Une erreur est survenue."}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={() => refresh()}>
+            <Text style={styles.retryButtonLabel}>Réessayer</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    if (!dashboard) {
+      return null;
+    }
+
+    return (
+      <>
+        <View style={styles.avatarContainer}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarInitials}>{dashboard.initials}</Text>
+          </View>
+          <View>
+            <Text style={styles.displayName}>{dashboard.display_name}</Text>
+            <Text style={styles.levelLabel}>Niveau {dashboard.level}</Text>
+            <Text style={styles.xpText}>
+              {dashboard.current_xp} XP / {dashboard.xp_to_next} XP
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.statsContainer}>
+          {dashboard.domain_stats.map((stat) => {
+            const color = DOMAIN_COLORS[stat.domain_key] ?? "#58a6ff";
+            return (
+              <View key={stat.domain_id} style={styles.statRow}>
+                <View style={styles.statHeader}>
+                  <Text style={styles.statLabel}>
+                    {stat.icon ? `${stat.icon} ` : ""}
+                    {stat.domain_name}
+                  </Text>
+                  <Text style={styles.statValue}>{Math.round(stat.progress_ratio * 100)}%</Text>
+                </View>
+                <View style={styles.progressBarBackground}>
+                  <View
+                    style={[
+                      styles.progressBarFill,
+                      {
+                        width: `${Math.min(stat.progress_ratio * 100, 100)}%`,
+                        backgroundColor: color,
+                      },
+                    ]}
+                  />
+                </View>
+                <Text style={styles.statSubtitle}>
+                  {stat.weekly_points} pts / {stat.weekly_target} visés • {stat.weekly_xp} XP
+                </Text>
+              </View>
+            );
+          })}
+        </View>
+
+        <View style={styles.actionButtons}>
+          <TouchableOpacity
+            style={[styles.ctaButton, styles.questsButton]}
+            onPress={() => router.push("/quests")}
+            activeOpacity={0.85}
+          >
+            <Feather name="target" size={28} color="#ffffff" />
+            <Text style={styles.ctaLabel}>Mes Quêtes</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.ctaButton, styles.progressButton]}
+            onPress={() => router.push("/progression")}
+            activeOpacity={0.85}
+          >
+            <Feather name="trending-up" size={28} color="#ffffff" />
+            <Text style={styles.ctaLabel}>Progression</Text>
+          </TouchableOpacity>
+        </View>
+      </>
+    );
+  };
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -28,63 +130,11 @@ export default function Index() {
         <ScrollView
           contentContainerStyle={styles.container}
           showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={isRefreshing} onRefresh={() => refresh()} tintColor="#58a6ff" />
+          }
         >
-          <View style={styles.avatarContainer}>
-            <View style={styles.avatar}>
-              <Text style={styles.avatarInitials}>JD</Text>
-            </View>
-            <View>
-              <Text style={styles.levelLabel}>Niveau 12</Text>
-              <Text style={styles.xpText}>340 XP / 500 XP</Text>
-            </View>
-          </View>
-
-          <View style={styles.statsContainer}>
-            {STAT_BARS.map((stat) => (
-              <View key={stat.label} style={styles.statRow}>
-                <View style={styles.statHeader}>
-                  <Text style={styles.statLabel}>
-                    {stat.icon} {stat.label}
-                  </Text>
-                  <Text style={styles.statValue}>
-                    {Math.round(stat.value * 100)}%
-                  </Text>
-                </View>
-                <View style={styles.progressBarBackground}>
-                  <View
-                    style={[
-                      styles.progressBarFill,
-                      {
-                        width: `${Math.min(stat.value * 100, 100)}%`,
-                        backgroundColor: stat.color,
-                      },
-                    ]}
-                  />
-                </View>
-
-              </View>
-            ))}
-          </View>
-
-          <View style={styles.actionButtons}>
-            <TouchableOpacity
-              style={[styles.ctaButton, styles.questsButton]}
-              onPress={() => router.push("/quests")}
-              activeOpacity={0.85}
-            >
-              <Feather name="target" size={28} color="#ffffff" />
-              <Text style={styles.ctaLabel}>Mes Quêtes</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[styles.ctaButton, styles.progressButton]}
-              onPress={() => router.push("/progression")}
-              activeOpacity={0.85}
-            >
-              <Feather name="trending-up" size={28} color="#ffffff" />
-              <Text style={styles.ctaLabel}>Progression</Text>
-            </TouchableOpacity>
-          </View>
+          {renderContent()}
         </ScrollView>
         <BottomNav />
       </View>
@@ -130,11 +180,16 @@ const styles = StyleSheet.create({
     fontSize: 26,
     fontWeight: "700",
   },
-  levelLabel: {
-    color: "white",
+  displayName: {
+    color: "#f8fafc",
     fontSize: 18,
     fontWeight: "700",
     marginBottom: 4,
+  },
+  levelLabel: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
   },
   xpText: {
     color: "#8b949e",
@@ -143,10 +198,31 @@ const styles = StyleSheet.create({
   statsContainer: {
     gap: 16,
   },
-  sectionTitle: {
-    color: "white",
-    fontSize: 20,
-    fontWeight: "700",
+  loadingContainer: {
+    paddingVertical: 120,
+    gap: 16,
+    alignItems: "center",
+  },
+  loadingLabel: {
+    color: "#cbd5f5",
+    fontSize: 16,
+    textAlign: "center",
+  },
+  errorLabel: {
+    color: "#f87171",
+    fontSize: 16,
+    textAlign: "center",
+    paddingHorizontal: 12,
+  },
+  retryButton: {
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: "#1f6feb",
+  },
+  retryButtonLabel: {
+    color: "#f8fafc",
+    fontWeight: "600",
   },
   statRow: {
     backgroundColor: "#161b22",
@@ -166,6 +242,12 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
   },
+  statValue: {
+    color: "#8b949e",
+    fontSize: 14,
+    fontWeight: "500",
+    textAlign: "right",
+  },
   progressBarBackground: {
     height: 12,
     borderRadius: 8,
@@ -175,12 +257,11 @@ const styles = StyleSheet.create({
   progressBarFill: {
     height: "100%",
     backgroundColor: "#2ea043",
+    borderRadius: 8,
   },
-  statValue: {
+  statSubtitle: {
     color: "#8b949e",
-    fontSize: 14,
-    fontWeight: "500",
-    textAlign: "right",
+    fontSize: 13,
   },
   actionButtons: {
     flexDirection: "row",

--- a/app/progression.tsx
+++ b/app/progression.tsx
@@ -1,179 +1,165 @@
 import { useRouter } from "expo-router";
-import { Feather } from "@expo/vector-icons";
+import { useMemo } from "react";
 import {
-  FlatList,
+  ActivityIndicator,
   Pressable,
+  RefreshControl,
   SafeAreaView,
   StyleSheet,
   Text,
   View,
+  FlatList,
 } from "react-native";
+import { Feather } from "@expo/vector-icons";
+
 import BottomNav from "../components/BottomNav";
+import { useHabitData } from "../context/HabitDataContext";
 import { CATEGORIES, type CategoryKey } from "../constants/categories";
 
-type HistoryItem = {
-  id: string;
-  action: string;
-  date: string;
-  xp: number;
-  category: CategoryKey;
-};
+function formatHistoryDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat("fr-FR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 
-const RECENT_HISTORY: HistoryItem[] = [
-  {
-    id: "h1",
-    action: "Hydratation du matin",
-    date: "Aujourd’hui • 08:30",
-    xp: 15,
-    category: "health",
-  },
-  {
-    id: "h2",
-    action: "Méditation express",
-    date: "Aujourd’hui • 07:10",
-    xp: 20,
-    category: "wellness",
-  },
-  {
-    id: "h3",
-    action: "Revue budget",
-    date: "Hier • 19:45",
-    xp: 25,
-    category: "finance",
-  },
-  {
-    id: "h4",
-    action: "Lecture pro",
-    date: "Hier • 15:20",
-    xp: 18,
-    category: "work",
-  },
-];
+  const todayLabel = now.toDateString();
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  const dateLabel = date.toDateString();
 
-const WEEKLY_STATS = [
-  {
-    id: "health",
-    icon: "⚡",
-    label: "Santé",
-    highlight: "+35 XP",
-    highlightColor: "#34d399",
-  },
-  {
-    id: "finance",
-    icon: "💰",
-    label: "Finances",
-    highlight: "+20 XP",
-    highlightColor: "#facc15",
-  },
-  {
-    id: "work",
-    icon: "📚",
-    label: "Travail",
-    highlight: "+15 XP",
-    highlightColor: "#60a5fa",
-  },
-  {
-    id: "relations",
-    icon: "❤️",
-    label: "Relations",
-    highlight: "+6 XP",
-    highlightColor: "#f472b6",
-  },
-];
-
-const UNLOCKED_BADGES = [
-  {
-    id: "b1",
-    icon: "🏆",
-    title: "3 jours consécutifs",
-    subtitle: "Continue comme ça !",
-  },
-];
+  if (dateLabel === todayLabel) {
+    return `Aujourd’hui • ${formatter.format(date)}`;
+  }
+  if (dateLabel === yesterday.toDateString()) {
+    return `Hier • ${formatter.format(date)}`;
+  }
+  return `${date.toLocaleDateString("fr-FR")} • ${formatter.format(date)}`;
+}
 
 export default function ProgressionScreen() {
   const router = useRouter();
+  const {
+    state: { status, progression, errorMessage },
+    refresh,
+    isRefreshing,
+  } = useHabitData();
 
+  const historyItems = useMemo(() => progression?.recent_history ?? [], [progression]);
+  const weeklyStats = useMemo(() => progression?.weekly_stats ?? [], [progression]);
+  const badges = useMemo(() => progression?.badges ?? [], [progression]);
+
+  if ((status === "loading" || status === "idle") && !progression) {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={[styles.screen, styles.centered]}>
+          <ActivityIndicator size="large" color="#58a6ff" />
+          <Text style={styles.loadingLabel}>Chargement de votre progression…</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (status === "error" && !progression) {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={[styles.screen, styles.centered]}>
+          <Text style={styles.errorLabel}>{errorMessage ?? "Impossible de charger la progression."}</Text>
+          <Pressable style={styles.retryButton} onPress={() => refresh()}>
+            <Text style={styles.retryButtonLabel}>Réessayer</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.screen}>
         <FlatList
-          contentContainerStyle={styles.content}
+          data={[]}
+          keyExtractor={(_, index) => index.toString()}
+          renderItem={() => null}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl refreshing={isRefreshing} onRefresh={() => refresh()} tintColor="#58a6ff" />
+          }
           ListHeaderComponent={
             <>
               <View style={styles.headerRow}>
-                <Pressable
-                  accessibilityRole="button"
-                  onPress={() => router.push("/")}
-                  style={styles.backButton}
-                >
+                <Pressable accessibilityRole="button" onPress={() => router.push("/")} style={styles.backButton}>
                   <Feather name="chevron-left" size={22} color="#e5e7eb" />
                 </Pressable>
                 <Text style={styles.headerTitle}>Ma Progression</Text>
               </View>
-
               <Text style={styles.headerSubtitle}>
-                Suis ton évolution et découvre les récompenses débloquées.
+                Suivez l’impact de vos habitudes et découvrez les récompenses débloquées.
               </Text>
 
               <View style={styles.card}>
                 <Text style={styles.cardTitle}>Historique récent</Text>
-                <View>
-                  {RECENT_HISTORY.map((item, index) => (
-                    <View
-                      key={item.id}
-                      style={[
-                        styles.historyItem,
-                        index !== RECENT_HISTORY.length - 1 && styles.historyItemSpacing,
-                      ]}
-                    >
-                      <Text style={styles.historyIcon}>
-                        {CATEGORIES[item.category].icon}
-                      </Text>
-                      <View style={styles.historyContent}>
-                        <Text style={styles.historyAction}>{item.action}</Text>
-                        <Text style={styles.historyDate}>{item.date}</Text>
+                {historyItems.length === 0 ? (
+                  <Text style={styles.emptyText}>Aucun log enregistré récemment.</Text>
+                ) : (
+                  historyItems.map((item) => {
+                    const category = CATEGORIES[item.domain_key as CategoryKey] ?? null;
+                    const icon = item.icon ?? category?.icon ?? "⭐";
+                    return (
+                      <View key={item.id} style={styles.historyItem}>
+                        <Text style={styles.historyIcon}>{icon}</Text>
+                        <View style={styles.historyContent}>
+                          <Text style={styles.historyAction}>{item.title}</Text>
+                          <Text style={styles.historyDate}>{formatHistoryDate(item.occurred_at)}</Text>
+                        </View>
+                        <Text style={styles.historyXp}>+{item.xp_awarded} XP</Text>
                       </View>
-                      <Text style={styles.historyXp}>+{item.xp} XP</Text>
-                    </View>
-                  ))}
-                </View>
+                    );
+                  })
+                )}
               </View>
 
               <View style={styles.card}>
                 <Text style={styles.cardTitle}>Statistiques hebdo</Text>
-                <View style={styles.statsGrid}>
-                  {WEEKLY_STATS.map((stat) => (
-                    <View key={stat.id} style={styles.statCard}>
-                      <Text style={styles.statIcon}>{stat.icon}</Text>
-                      <Text style={styles.statLabel}>{stat.label}</Text>
-                      <Text
-                        style={[styles.statHighlight, { color: stat.highlightColor }]}
-                      >
-                        {stat.highlight}
-                      </Text>
-                    </View>
-                  ))}
-                </View>
+                {weeklyStats.length === 0 ? (
+                  <Text style={styles.emptyText}>Aucune donnée pour cette semaine.</Text>
+                ) : (
+                  <View style={styles.statsGrid}>
+                    {weeklyStats.map((stat) => {
+                      const category = CATEGORIES[stat.domain_key as CategoryKey] ?? null;
+                      const icon = stat.icon ?? category?.icon ?? "📈";
+                      const label = category?.label ?? stat.domain_name;
+                      return (
+                        <View key={stat.domain_id} style={styles.statCard}>
+                          <Text style={styles.statIcon}>{icon}</Text>
+                          <Text style={styles.statLabel}>{label}</Text>
+                          <Text style={styles.statHighlight}>+{stat.weekly_xp} XP</Text>
+                          <Text style={styles.statSubHighlight}>{stat.weekly_points} pts</Text>
+                        </View>
+                      );
+                    })}
+                  </View>
+                )}
               </View>
 
               <View style={styles.badgeCard}>
                 <Text style={styles.badgeCardTitle}>Badges débloqués</Text>
-                {UNLOCKED_BADGES.map((badge) => (
-                  <View key={badge.id} style={styles.badgeRow}>
-                    <Text style={styles.badgeIcon}>{badge.icon}</Text>
-                    <View style={styles.badgeContent}>
-                      <Text style={styles.badgeTitle}>{badge.title}</Text>
-                      <Text style={styles.badgeSubtitle}>{badge.subtitle}</Text>
+                {badges.length === 0 ? (
+                  <Text style={styles.emptyText}>Continuez à progresser pour débloquer vos premiers badges !</Text>
+                ) : (
+                  badges.map((badge) => (
+                    <View key={badge.id} style={styles.badgeRow}>
+                      <Text style={styles.badgeIcon}>🏆</Text>
+                      <View style={styles.badgeContent}>
+                        <Text style={styles.badgeTitle}>{badge.title}</Text>
+                        <Text style={styles.badgeSubtitle}>{badge.subtitle}</Text>
+                      </View>
                     </View>
-                  </View>
-                ))}
+                  ))
+                )}
               </View>
             </>
           }
-          data={[]}
-          keyExtractor={(_, index) => index.toString()}
-          renderItem={() => null}
         />
         <BottomNav />
       </View>
@@ -190,10 +176,35 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#0f172a",
   },
-  content: {
+  listContent: {
     paddingHorizontal: 24,
     paddingBottom: 140,
     paddingTop: 28,
+    gap: 20,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: "rgba(30, 41, 59, 0.8)",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.25)",
+  },
+  headerTitle: {
+    color: "#e2e8f0",
+    fontSize: 22,
+    fontWeight: "700",
+  },
+  headerSubtitle: {
+    color: "#94a3b8",
+    fontSize: 15,
   },
   card: {
     backgroundColor: "rgba(30, 41, 59, 0.65)",
@@ -201,134 +212,138 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 20,
     padding: 20,
-    marginBottom: 26,
+    gap: 16,
   },
   cardTitle: {
-    color: "#c4b5fd",
+    color: "#e2e8f0",
     fontSize: 18,
-    fontWeight: "700",
-    marginBottom: 18,
-  },
-  headerRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 16,
-  },
-  backButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 12,
-    backgroundColor: "rgba(17, 24, 39, 0.8)",
-    alignItems: "center",
-    justifyContent: "center",
-    marginRight: 16,
-  },
-  headerTitle: {
-    color: "#f9fafb",
-    fontSize: 24,
-    fontWeight: "700",
-  },
-  headerSubtitle: {
-    color: "#9ca3af",
-    fontSize: 14,
-    lineHeight: 20,
-    marginBottom: 24,
-  },
-  historyItem: {
-    backgroundColor: "rgba(15, 23, 42, 0.6)",
-    borderRadius: 16,
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  historyItemSpacing: {
-    marginBottom: 12,
-  },
-  historyIcon: {
-    fontSize: 26,
-    marginRight: 12,
-  },
-  historyContent: {
-    flex: 1,
-  },
-  historyAction: {
-    color: "#e5e7eb",
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 4,
-  },
-  historyDate: {
-    color: "#6b7280",
-    fontSize: 12,
-  },
-  historyXp: {
-    color: "#c4b5fd",
-    fontSize: 14,
     fontWeight: "700",
   },
   statsGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    justifyContent: "space-between",
+    gap: 12,
   },
   statCard: {
-    width: "48%",
+    flexBasis: "48%",
     backgroundColor: "rgba(15, 23, 42, 0.65)",
     borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "rgba(59, 130, 246, 0.25)",
     padding: 16,
-    marginBottom: 12,
+    gap: 8,
   },
   statIcon: {
     fontSize: 24,
-    marginBottom: 10,
   },
   statLabel: {
-    color: "#9ca3af",
-    fontSize: 12,
-    marginBottom: 6,
+    color: "#e2e8f0",
+    fontSize: 16,
+    fontWeight: "600",
   },
   statHighlight: {
-    fontSize: 16,
-    fontWeight: "700",
+    color: "#34d399",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  statSubHighlight: {
+    color: "#94a3b8",
+    fontSize: 13,
   },
   badgeCard: {
-    backgroundColor: "rgba(202, 138, 4, 0.16)",
-    borderColor: "rgba(234, 179, 8, 0.35)",
+    backgroundColor: "rgba(15, 23, 42, 0.85)",
+    borderColor: "rgba(59, 130, 246, 0.3)",
     borderWidth: 1,
-    borderRadius: 22,
-    padding: 22,
-    marginBottom: 40,
+    borderRadius: 20,
+    padding: 20,
+    gap: 16,
   },
   badgeCardTitle: {
-    color: "#facc15",
+    color: "#f8fafc",
     fontSize: 18,
     fontWeight: "700",
-    marginBottom: 18,
   },
   badgeRow: {
     flexDirection: "row",
     alignItems: "center",
-    backgroundColor: "rgba(15, 23, 42, 0.4)",
-    borderRadius: 18,
-    paddingVertical: 14,
-    paddingHorizontal: 16,
+    gap: 12,
   },
   badgeIcon: {
-    fontSize: 32,
-    marginRight: 14,
+    fontSize: 28,
   },
   badgeContent: {
     flex: 1,
+    gap: 4,
   },
   badgeTitle: {
-    color: "#fbbf24",
+    color: "#f9fafb",
     fontSize: 16,
-    fontWeight: "700",
-    marginBottom: 4,
+    fontWeight: "600",
   },
   badgeSubtitle: {
-    color: "#f3f4f6",
-    fontSize: 12,
+    color: "#cbd5f5",
+    fontSize: 14,
+  },
+  historyItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 16,
+    backgroundColor: "rgba(15, 23, 42, 0.65)",
+    borderWidth: 1,
+    borderColor: "rgba(75, 85, 99, 0.35)",
+    borderRadius: 20,
+    padding: 18,
+  },
+  historyIcon: {
+    fontSize: 24,
+  },
+  historyContent: {
+    flex: 1,
+    gap: 4,
+  },
+  historyAction: {
+    color: "#f8fafc",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  historyDate: {
+    color: "#94a3b8",
+    fontSize: 13,
+  },
+  historyXp: {
+    color: "#facc15",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  emptyText: {
+    color: "#cbd5f5",
+    fontSize: 15,
+    textAlign: "center",
+  },
+  centered: {
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 16,
+  },
+  loadingLabel: {
+    color: "#cbd5f5",
+    fontSize: 16,
+    textAlign: "center",
+  },
+  errorLabel: {
+    color: "#f87171",
+    fontSize: 16,
+    textAlign: "center",
+    paddingHorizontal: 12,
+  },
+  retryButton: {
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: "#1f6feb",
+  },
+  retryButtonLabel: {
+    color: "#f8fafc",
+    fontWeight: "600",
   },
 });

--- a/app/quests.tsx
+++ b/app/quests.tsx
@@ -1,234 +1,143 @@
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
+  ActivityIndicator,
+  Alert,
   FlatList,
   Pressable,
+  RefreshControl,
   SafeAreaView,
   StyleSheet,
   Text,
-  TextInput,
   View,
 } from "react-native";
 import { Feather } from "@expo/vector-icons";
+
 import BottomNav from "../components/BottomNav";
-import {
-  CATEGORIES,
-  CATEGORY_OPTIONS,
-  type CategoryKey,
-} from "../constants/categories";
-
-type Task = {
-  id: string;
-  title: string;
-  category: CategoryKey;
-  xp: number;
-  completed: boolean;
-};
-
-const INITIAL_TASKS: Task[] = [
-  {
-    id: "1",
-    title: "Hydratation du matin",
-    category: "health",
-    xp: 15,
-    completed: false,
-  },
-  {
-    id: "2",
-    title: "Méditation express",
-    category: "wellness",
-    xp: 20,
-    completed: false,
-  },
-  {
-    id: "3",
-    title: "Revue budget",
-    category: "finance",
-    xp: 25,
-    completed: true,
-  },
-  {
-    id: "4",
-    title: "Lecture pro",
-    category: "work",
-    xp: 18,
-    completed: false,
-  },
-];
+import { useHabitData } from "../context/HabitDataContext";
+import { CATEGORIES, type CategoryKey } from "../constants/categories";
 
 export default function QuestsScreen() {
   const router = useRouter();
-  const [tasks, setTasks] = useState(INITIAL_TASKS);
-  const [showAddTask, setShowAddTask] = useState(false);
-  const [newTaskCategory, setNewTaskCategory] = useState<CategoryKey>(
-    CATEGORY_OPTIONS[0]
-  );
-  const [newTaskText, setNewTaskText] = useState("");
-  const [categoryPickerOpen, setCategoryPickerOpen] = useState(false);
+  const {
+    state: { status, tasks, errorMessage },
+    refresh,
+    isRefreshing,
+    completeTask,
+  } = useHabitData();
+  const [completingTaskId, setCompletingTaskId] = useState<string | null>(null);
 
-  const toggleTask = (id: string) => {
-    setTasks((prev) =>
-      prev.map((task) =>
-        task.id === id ? { ...task, completed: !task.completed } : task
-      )
-    );
-  };
+  const questItems = useMemo(() => tasks?.tasks ?? [], [tasks]);
+  const isInitialLoading =
+    (status === "loading" || status === "idle") && questItems.length === 0;
 
-  const handleCloseForm = () => {
-    setShowAddTask(false);
-    setCategoryPickerOpen(false);
-    setNewTaskText("");
-  };
-
-  const addTask = () => {
-    if (!newTaskText.trim()) {
+  const handleToggleTask = async (taskId: string, alreadyCompleted: boolean) => {
+    if (alreadyCompleted || completingTaskId) {
       return;
     }
 
-    setTasks((prev) => [
-      {
-        id: Date.now().toString(),
-        title: newTaskText.trim(),
-        category: newTaskCategory,
-        xp: 20,
-        completed: false,
-      },
-      ...prev,
-    ]);
+    try {
+      setCompletingTaskId(taskId);
+      await completeTask(taskId);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Impossible d'enregistrer cette tâche.";
+      Alert.alert("Erreur", message);
+    } finally {
+      setCompletingTaskId(null);
+    }
+  };
 
-    handleCloseForm();
+  const renderItem = ({
+    item,
+  }: {
+    item: (typeof questItems)[number];
+  }) => {
+    const category = CATEGORIES[item.domain_key as CategoryKey] ?? null;
+    const icon = item.icon ?? category?.icon ?? "⭐";
+    const label = category?.label ?? item.domain_name;
+
+    const isLoading = completingTaskId === item.id;
+
+    return (
+      <Pressable
+        style={[styles.taskCard, item.completed_today && styles.taskCardCompleted]}
+        onPress={() => handleToggleTask(item.id, item.completed_today)}
+        disabled={item.completed_today || isLoading}
+      >
+        <View
+          style={[
+            styles.checkboxButton,
+            item.completed_today ? styles.checkboxButtonCompleted : styles.checkboxButtonDefault,
+          ]}
+        >
+          {item.completed_today && <Feather name="check" size={16} color="#0f172a" />}
+        </View>
+        <View style={styles.taskContent}>
+          <Text style={[styles.taskTitle, item.completed_today && styles.taskTitleCompleted]}>
+            {item.title}
+          </Text>
+          <View style={styles.taskMetaRow}>
+            <Text style={styles.taskCategory}>
+              {icon} {label}
+            </Text>
+            <Text style={styles.taskXp}>+{item.xp} XP</Text>
+          </View>
+        </View>
+        {isLoading && <ActivityIndicator size="small" color="#f8fafc" />}
+      </Pressable>
+    );
+  };
+
+  const ListEmptyComponent = () => {
+    if (isInitialLoading) {
+      return (
+        <View style={styles.emptyState}>
+          <ActivityIndicator size="large" color="#58a6ff" />
+          <Text style={styles.emptyStateLabel}>Chargement des quêtes…</Text>
+        </View>
+      );
+    }
+
+    if (status === "error" && questItems.length === 0) {
+      return (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyStateLabel}>{errorMessage ?? "Impossible de charger vos quêtes."}</Text>
+          <Pressable style={styles.retryButton} onPress={() => refresh()}>
+            <Text style={styles.retryButtonLabel}>Réessayer</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    return (
+      <View style={styles.emptyState}>
+        <Text style={styles.emptyStateLabel}>Aucune quête pour le moment.</Text>
+      </View>
+    );
   };
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.screen}>
         <FlatList
-          data={tasks}
+          data={questItems}
           keyExtractor={(item) => item.id}
-          renderItem={({ item }) => (
-            <Pressable
-              style={[styles.taskCard, item.completed && styles.taskCardCompleted]}
-              onPress={() => toggleTask(item.id)}
-            >
-              <Pressable
-                onPress={(event) => {
-                  event.stopPropagation();
-                  toggleTask(item.id);
-                }}
-                hitSlop={10}
-                style={[
-                  styles.checkboxButton,
-                  item.completed
-                    ? styles.checkboxButtonCompleted
-                    : styles.checkboxButtonDefault,
-                ]}
-              >
-                {item.completed && (
-                  <Feather name="check" size={16} color="#0f172a" />
-                )}
-              </Pressable>
-              <View style={styles.taskContent}>
-                <Text
-                  style={[styles.taskTitle, item.completed && styles.taskTitleCompleted]}
-                >
-                  {item.title}
-                </Text>
-                <View style={styles.taskMetaRow}>
-                  <Text style={styles.taskCategory}>
-                    {CATEGORIES[item.category].icon} {CATEGORIES[item.category].label}
-                  </Text>
-                  <Text style={styles.taskXp}>+{item.xp} XP</Text>
-                </View>
-              </View>
-            </Pressable>
-          )}
+          renderItem={renderItem}
+          ListEmptyComponent={ListEmptyComponent}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={isRefreshing} onRefresh={() => refresh()} tintColor="#58a6ff" />
+          }
           ListHeaderComponent={
             <View style={styles.header}>
-              <Pressable
-                accessibilityRole="button"
-                onPress={() => router.push("/")}
-                style={styles.backButton}
-              >
+              <Pressable accessibilityRole="button" onPress={() => router.push("/")} style={styles.backButton}>
                 <Feather name="chevron-left" size={22} color="#e5e7eb" />
               </Pressable>
               <Text style={styles.title}>Mes Quêtes du jour</Text>
             </View>
           }
-          ListFooterComponent={
-            <View style={styles.footerContent}>
-              {!showAddTask ? (
-                <Pressable
-                  style={styles.addQuickButton}
-                  onPress={() => setShowAddTask(true)}
-                >
-                  <Feather name="plus" size={18} color="#f9fafb" />
-                  <Text style={styles.addQuickLabel}>Ajouter une tâche</Text>
-                </Pressable>
-              ) : (
-                <View style={styles.formCard}>
-                  <Text style={styles.formTitle}>Nouvelle tâche</Text>
-
-                  <View style={styles.fieldBlock}>
-                    <Text style={styles.fieldLabel}>Catégorie</Text>
-                    <Pressable
-                      style={styles.selectTrigger}
-                      onPress={() => setCategoryPickerOpen((prev) => !prev)}
-                    >
-                      <Text style={styles.selectTriggerText}>
-                        {CATEGORIES[newTaskCategory].icon} {" "}
-                        {CATEGORIES[newTaskCategory].label}
-                      </Text>
-                      <Feather
-                        name={categoryPickerOpen ? "chevron-up" : "chevron-down"}
-                        size={16}
-                        color="#cbd5f5"
-                      />
-                    </Pressable>
-                    {categoryPickerOpen && (
-                      <View style={styles.selectOptions}>
-                        {CATEGORY_OPTIONS.map((category) => (
-                          <Pressable
-                            key={category}
-                            style={styles.selectOption}
-                            onPress={() => {
-                              setNewTaskCategory(category);
-                              setCategoryPickerOpen(false);
-                            }}
-                          >
-                            <Text style={styles.selectOptionText}>
-                              {CATEGORIES[category].icon} {CATEGORIES[category].label}
-                            </Text>
-                          </Pressable>
-                        ))}
-                      </View>
-                    )}
-                  </View>
-
-                  <View style={styles.fieldBlock}>
-                    <Text style={styles.fieldLabel}>Action</Text>
-                    <TextInput
-                      value={newTaskText}
-                      onChangeText={setNewTaskText}
-                      placeholder="Ex: Méditer 10 minutes"
-                      placeholderTextColor="#64748b"
-                      style={styles.input}
-                    />
-                  </View>
-
-                  <View style={styles.formActions}>
-                    <Pressable style={styles.cancelButton} onPress={handleCloseForm}>
-                      <Text style={styles.cancelLabel}>Annuler</Text>
-                    </Pressable>
-                    <Pressable style={styles.submitButton} onPress={addTask}>
-                      <Text style={styles.submitLabel}>Valider</Text>
-                    </Pressable>
-                  </View>
-                </View>
-              )}
-            </View>
-          }
-          contentContainerStyle={styles.content}
-          showsVerticalScrollIndicator={false}
         />
         <BottomNav />
       </View>
@@ -245,203 +154,108 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#0f172a",
   },
-  content: {
+  listContent: {
     paddingHorizontal: 24,
-    paddingTop: 32,
     paddingBottom: 140,
+    paddingTop: 28,
+    gap: 16,
+    flexGrow: 1,
   },
   header: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 16,
-    marginBottom: 28,
+    marginBottom: 12,
   },
   backButton: {
-    width: 44,
-    height: 44,
+    width: 40,
+    height: 40,
     borderRadius: 12,
+    backgroundColor: "rgba(30, 41, 59, 0.8)",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "rgba(15, 23, 42, 0.8)",
+    marginRight: 12,
     borderWidth: 1,
-    borderColor: "rgba(148, 163, 184, 0.2)",
+    borderColor: "rgba(148, 163, 184, 0.25)",
   },
   title: {
-    color: "white",
-    fontSize: 26,
+    color: "#e2e8f0",
+    fontSize: 22,
     fontWeight: "700",
   },
   taskCard: {
     flexDirection: "row",
-    alignItems: "flex-start",
-    gap: 12,
-    backgroundColor: "rgba(30, 41, 59, 0.7)",
+    alignItems: "center",
+    gap: 14,
+    backgroundColor: "rgba(30, 41, 59, 0.75)",
     padding: 18,
-    borderRadius: 20,
+    borderRadius: 18,
     borderWidth: 1,
-    borderColor: "rgba(75, 85, 99, 0.45)",
-    marginBottom: 12,
+    borderColor: "rgba(148, 163, 184, 0.2)",
   },
   taskCardCompleted: {
-    borderColor: "rgba(34, 197, 94, 0.55)",
-    backgroundColor: "rgba(6, 95, 70, 0.2)",
+    opacity: 0.5,
   },
   checkboxButton: {
-    width: 28,
-    height: 28,
+    width: 26,
+    height: 26,
     borderRadius: 8,
-    borderWidth: 2,
     alignItems: "center",
     justifyContent: "center",
   },
   checkboxButtonDefault: {
-    backgroundColor: "rgba(15, 23, 42, 0.9)",
-    borderColor: "rgba(75, 85, 99, 0.6)",
+    borderWidth: 2,
+    borderColor: "#38bdf8",
+    backgroundColor: "transparent",
   },
   checkboxButtonCompleted: {
-    backgroundColor: "#22c55e",
-    borderColor: "#22c55e",
+    backgroundColor: "#38bdf8",
   },
   taskContent: {
     flex: 1,
-    gap: 6,
+    gap: 4,
   },
   taskTitle: {
-    color: "white",
+    color: "#f9fafb",
     fontSize: 16,
     fontWeight: "600",
   },
   taskTitleCompleted: {
     textDecorationLine: "line-through",
-    color: "#6b7280",
+    color: "rgba(226, 232, 240, 0.6)",
   },
   taskMetaRow: {
     flexDirection: "row",
+    justifyContent: "space-between",
     alignItems: "center",
-    gap: 8,
-    flexWrap: "wrap",
   },
   taskCategory: {
-    fontSize: 12,
-    color: "#94a3b8",
+    color: "#cbd5f5",
+    fontSize: 14,
   },
   taskXp: {
-    fontSize: 12,
-    fontWeight: "700",
-    color: "#c084fc",
-  },
-  footerContent: {
-    marginTop: 16,
-  },
-  addQuickButton: {
-    height: 54,
-    borderRadius: 16,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 10,
-    backgroundColor: "#7c3aed",
-    borderWidth: 1,
-    borderColor: "rgba(147, 51, 234, 0.4)",
-  },
-  addQuickLabel: {
-    color: "white",
-    fontSize: 16,
-    fontWeight: "700",
-  },
-  formCard: {
-    backgroundColor: "rgba(30, 41, 59, 0.7)",
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: "rgba(75, 85, 99, 0.45)",
-    padding: 20,
-    gap: 20,
-  },
-  formTitle: {
-    color: "white",
-    fontSize: 20,
-    fontWeight: "700",
-  },
-  fieldBlock: {
-    gap: 10,
-  },
-  fieldLabel: {
-    color: "#cbd5f5",
-    fontSize: 13,
-    textTransform: "uppercase",
-    letterSpacing: 0.6,
-    fontWeight: "700",
-  },
-  selectTrigger: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    borderRadius: 14,
-    backgroundColor: "rgba(15, 23, 42, 0.9)",
-    borderWidth: 1,
-    borderColor: "rgba(71, 85, 105, 0.6)",
-  },
-  selectTriggerText: {
-    color: "#e2e8f0",
+    color: "#f9fafb",
     fontSize: 14,
     fontWeight: "600",
   },
-  selectOptions: {
-    marginTop: 8,
-    borderRadius: 14,
-    overflow: "hidden",
-    borderWidth: 1,
-    borderColor: "rgba(71, 85, 105, 0.6)",
-    backgroundColor: "rgba(15, 23, 42, 0.95)",
-  },
-  selectOption: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  selectOptionText: {
-    color: "#e2e8f0",
-    fontSize: 14,
-  },
-  input: {
-    borderRadius: 14,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    backgroundColor: "rgba(15, 23, 42, 0.9)",
-    borderWidth: 1,
-    borderColor: "rgba(71, 85, 105, 0.6)",
-    color: "white",
-    fontSize: 15,
-  },
-  formActions: {
-    flexDirection: "row",
+  emptyState: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 120,
     gap: 12,
   },
-  cancelButton: {
-    flex: 1,
-    borderRadius: 12,
-    paddingVertical: 14,
-    backgroundColor: "rgba(51, 65, 85, 0.8)",
-    alignItems: "center",
-    justifyContent: "center",
+  emptyStateLabel: {
+    color: "#cbd5f5",
+    fontSize: 16,
+    textAlign: "center",
   },
-  cancelLabel: {
-    color: "#e2e8f0",
-    fontSize: 15,
+  retryButton: {
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: "#1f6feb",
+  },
+  retryButtonLabel: {
+    color: "#f8fafc",
     fontWeight: "600",
-  },
-  submitButton: {
-    flex: 1,
-    borderRadius: 12,
-    paddingVertical: 14,
-    backgroundColor: "#7c3aed",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  submitLabel: {
-    color: "white",
-    fontSize: 15,
-    fontWeight: "700",
   },
 });

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,6 @@
 """API routers for the Habit Projects backend."""
 
 from .task_logs import router as task_logs_router
+from .users import router as users_router
 
-__all__ = ["task_logs_router"]
+__all__ = ["task_logs_router", "users_router"]

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,0 +1,274 @@
+"""API routes for accessing user dashboard data."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..config import get_settings
+from ..database import get_session
+from ..models import (
+    Domain,
+    ProgressSnapshot,
+    SnapshotPeriod,
+    Streak,
+    TaskLog,
+    TaskTemplate,
+    User,
+    UserDomainSetting,
+    UserLevel,
+    UserTask,
+)
+from ..schemas import (
+    BadgeItem,
+    DashboardDomainStat,
+    DashboardResponse,
+    HistoryItem,
+    ProgressionResponse,
+    TaskListItem,
+    TaskListResponse,
+    UserSummary,
+    WeeklyStat,
+)
+from ..services.task_logs import monday_start
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def get_db_session():
+    with get_session() as session:
+        yield session
+
+
+def get_today_dates() -> tuple[datetime, datetime]:
+    settings = get_settings()
+    tz = ZoneInfo(settings.timezone)
+    now = datetime.now(tz)
+    start_of_day = datetime(now.year, now.month, now.day, tzinfo=tz)
+    end_of_day = start_of_day.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return start_of_day, end_of_day
+
+
+def compute_initials(name: str) -> str:
+    parts = [part[0] for part in name.strip().split() if part]
+    if not parts:
+        return "?"
+    initials = "".join(parts[:2])
+    return initials.upper()
+
+
+def resolve_user(session: Session, user_id: UUID) -> User:
+    user = session.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilisateur introuvable.")
+    return user
+
+
+@router.get("", response_model=list[UserSummary])
+def list_users(session: Session = Depends(get_db_session)) -> list[UserSummary]:
+    stmt = select(User).order_by(User.display_name)
+    users = session.scalars(stmt).all()
+    return users
+
+
+@router.get("/{user_id}/dashboard", response_model=DashboardResponse)
+def get_dashboard(user_id: UUID, session: Session = Depends(get_db_session)) -> DashboardResponse:
+    user = resolve_user(session, user_id)
+
+    level = session.get(UserLevel, user_id)
+    if level:
+        current_level = level.current_level
+        current_xp = level.current_xp
+        xp_to_next = level.xp_to_next
+    else:
+        current_level = 1
+        current_xp = 0
+        xp_to_next = 100
+
+    today = datetime.now(ZoneInfo(get_settings().timezone)).date()
+    current_week = monday_start(today)
+
+    settings_stmt = (
+        select(UserDomainSetting, Domain, ProgressSnapshot)
+        .join(Domain, UserDomainSetting.domain_id == Domain.id)
+        .outerjoin(
+            ProgressSnapshot,
+            (
+                (ProgressSnapshot.user_id == user_id)
+                & (ProgressSnapshot.domain_id == Domain.id)
+                & (ProgressSnapshot.period == SnapshotPeriod.WEEK)
+                & (ProgressSnapshot.period_start_date == current_week)
+            ),
+        )
+        .where(UserDomainSetting.user_id == user_id, UserDomainSetting.is_enabled.is_(True))
+        .order_by(Domain.order_index)
+    )
+
+    domain_stats: list[DashboardDomainStat] = []
+    for domain_setting, domain, snapshot in session.execute(settings_stmt):
+        weekly_points = snapshot.points_total if snapshot else 0
+        weekly_xp = snapshot.xp_total if snapshot else 0
+        weekly_target = domain_setting.weekly_target_points or 0
+        progress = 0.0
+        if weekly_target > 0:
+            progress = min(weekly_points / weekly_target, 1.0)
+        domain_stats.append(
+            DashboardDomainStat(
+                domain_id=domain.id,
+                domain_key=domain.key,
+                domain_name=domain.name,
+                icon=domain.icon,
+                weekly_points=weekly_points,
+                weekly_target=weekly_target,
+                weekly_xp=weekly_xp,
+                progress_ratio=progress,
+            )
+        )
+
+    return DashboardResponse(
+        user_id=user.id,
+        display_name=user.display_name,
+        initials=compute_initials(user.display_name),
+        level=current_level,
+        current_xp=current_xp,
+        xp_to_next=xp_to_next,
+        domain_stats=domain_stats,
+    )
+
+
+@router.get("/{user_id}/tasks", response_model=TaskListResponse)
+def list_tasks(user_id: UUID, session: Session = Depends(get_db_session)) -> TaskListResponse:
+    user = resolve_user(session, user_id)
+    start_of_day, end_of_day = get_today_dates()
+
+    todays_logs_stmt = (
+        select(TaskLog.user_task_id)
+        .where(
+            TaskLog.user_id == user_id,
+            TaskLog.user_task_id.is_not(None),
+            TaskLog.occurred_at >= start_of_day,
+            TaskLog.occurred_at <= end_of_day,
+        )
+    )
+    todays_logs = {row[0] for row in session.execute(todays_logs_stmt) if row[0] is not None}
+
+    tasks_stmt = (
+        select(UserTask, Domain, TaskTemplate)
+        .join(Domain, UserTask.domain_id == Domain.id)
+        .outerjoin(TaskTemplate, UserTask.template_id == TaskTemplate.id)
+        .where(UserTask.user_id == user.id, UserTask.is_active.is_(True))
+        .order_by(UserTask.created_at.desc())
+    )
+
+    tasks: list[TaskListItem] = []
+    for user_task, domain, template in session.execute(tasks_stmt):
+        title = user_task.custom_title or (template.title if template else domain.name)
+        xp = user_task.custom_xp or (template.default_xp if template else 0)
+        tasks.append(
+            TaskListItem(
+                id=user_task.id,
+                title=title,
+                domain_id=domain.id,
+                domain_key=domain.key,
+                domain_name=domain.name,
+                icon=domain.icon,
+                xp=xp,
+                completed_today=user_task.id in todays_logs,
+            )
+        )
+
+    return TaskListResponse(user_id=user.id, tasks=tasks)
+
+
+@router.get("/{user_id}/progression", response_model=ProgressionResponse)
+def get_progression(user_id: UUID, session: Session = Depends(get_db_session)) -> ProgressionResponse:
+    _ = resolve_user(session, user_id)
+
+    history_stmt = (
+        select(TaskLog, Domain, UserTask, TaskTemplate)
+        .join(Domain, TaskLog.domain_id == Domain.id)
+        .outerjoin(UserTask, TaskLog.user_task_id == UserTask.id)
+        .outerjoin(TaskTemplate, UserTask.template_id == TaskTemplate.id)
+        .where(TaskLog.user_id == user_id)
+        .order_by(TaskLog.occurred_at.desc())
+        .limit(20)
+    )
+
+    recent_history: list[HistoryItem] = []
+    for log, domain, user_task, template in session.execute(history_stmt):
+        title = domain.name
+        if user_task:
+            title = user_task.custom_title or (template.title if template else domain.name)
+        recent_history.append(
+            HistoryItem(
+                id=log.id,
+                title=title,
+                occurred_at=log.occurred_at,
+                xp_awarded=log.xp_awarded,
+                domain_id=domain.id,
+                domain_key=domain.key,
+                domain_name=domain.name,
+                icon=domain.icon,
+            )
+        )
+
+    today = datetime.now(ZoneInfo(get_settings().timezone)).date()
+    current_week = monday_start(today)
+
+    stats_stmt = (
+        select(Domain, ProgressSnapshot)
+        .join(UserDomainSetting, (UserDomainSetting.domain_id == Domain.id) & (UserDomainSetting.user_id == user_id))
+        .outerjoin(
+            ProgressSnapshot,
+            (
+                (ProgressSnapshot.user_id == user_id)
+                & (ProgressSnapshot.domain_id == Domain.id)
+                & (ProgressSnapshot.period == SnapshotPeriod.WEEK)
+                & (ProgressSnapshot.period_start_date == current_week)
+            ),
+        )
+        .where(UserDomainSetting.is_enabled.is_(True))
+        .order_by(Domain.order_index)
+    )
+
+    weekly_stats: list[WeeklyStat] = []
+    for domain, snapshot in session.execute(stats_stmt):
+        weekly_stats.append(
+            WeeklyStat(
+                domain_id=domain.id,
+                domain_key=domain.key,
+                domain_name=domain.name,
+                icon=domain.icon,
+                weekly_points=snapshot.points_total if snapshot else 0,
+                weekly_xp=snapshot.xp_total if snapshot else 0,
+            )
+        )
+
+    streak_stmt = (
+        select(Streak, Domain)
+        .join(Domain, Streak.domain_id == Domain.id)
+        .where(Streak.user_id == user_id, Streak.current_streak_days > 0)
+        .order_by(Streak.current_streak_days.desc())
+    )
+
+    badges: list[BadgeItem] = []
+    for streak, domain in session.execute(streak_stmt):
+        badges.append(
+            BadgeItem(
+                id=f"streak-{streak.id}",
+                title=f"{streak.current_streak_days} jours consécutifs",
+                subtitle=f"{domain.name} • Meilleur : {streak.best_streak_days} jours",
+                domain_id=domain.id,
+            )
+        )
+
+    return ProgressionResponse(
+        user_id=user_id,
+        recent_history=recent_history,
+        weekly_stats=weekly_stats,
+        badges=badges,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from .api.task_logs import router as task_logs_router
+from .api.users import router as users_router
 from .config import get_settings
 
 settings = get_settings()
 
 app = FastAPI(title=settings.app_name)
 app.include_router(task_logs_router)
+app.include_router(users_router)
 
 
 @app.get("/health", tags=["health"])

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -122,3 +122,82 @@ class UserChallengeRead(BaseModel):
 
     class Config:
         model_config = ConfigDict(from_attributes=True)
+
+
+class UserSummary(BaseModel):
+    id: UUID
+    display_name: str
+
+    class Config:
+        model_config = ConfigDict(from_attributes=True)
+
+
+class DashboardDomainStat(BaseModel):
+    domain_id: int
+    domain_key: str
+    domain_name: str
+    icon: Optional[str]
+    weekly_points: int
+    weekly_target: int
+    weekly_xp: int
+    progress_ratio: float
+
+
+class DashboardResponse(BaseModel):
+    user_id: UUID
+    display_name: str
+    initials: str
+    level: int
+    current_xp: int
+    xp_to_next: int
+    domain_stats: list[DashboardDomainStat]
+
+
+class TaskListItem(BaseModel):
+    id: UUID
+    title: str
+    domain_id: int
+    domain_key: str
+    domain_name: str
+    icon: Optional[str]
+    xp: int
+    completed_today: bool
+
+
+class TaskListResponse(BaseModel):
+    user_id: UUID
+    tasks: list[TaskListItem]
+
+
+class HistoryItem(BaseModel):
+    id: UUID
+    title: str
+    occurred_at: datetime
+    xp_awarded: int
+    domain_id: int
+    domain_key: str
+    domain_name: str
+    icon: Optional[str]
+
+
+class WeeklyStat(BaseModel):
+    domain_id: int
+    domain_key: str
+    domain_name: str
+    icon: Optional[str]
+    weekly_points: int
+    weekly_xp: int
+
+
+class BadgeItem(BaseModel):
+    id: str
+    title: str
+    subtitle: str
+    domain_id: Optional[int]
+
+
+class ProgressionResponse(BaseModel):
+    user_id: UUID
+    recent_history: list[HistoryItem]
+    weekly_stats: list[WeeklyStat]
+    badges: list[BadgeItem]

--- a/context/HabitDataContext.tsx
+++ b/context/HabitDataContext.tsx
@@ -1,0 +1,119 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+import {
+  completeTaskLog,
+  fetchDashboard,
+  fetchProgression,
+  fetchTasks,
+  fetchUsers,
+} from "../lib/api";
+import type {
+  DashboardResponse,
+  ProgressionResponse,
+  TaskListResponse,
+  UserSummary,
+} from "../types/api";
+
+type HabitDataState = {
+  status: "idle" | "loading" | "ready" | "error";
+  errorMessage?: string;
+  user: UserSummary | null;
+  dashboard: DashboardResponse | null;
+  tasks: TaskListResponse | null;
+  progression: ProgressionResponse | null;
+};
+
+type HabitDataContextValue = {
+  state: HabitDataState;
+  refresh: () => Promise<void>;
+  completeTask: (taskId: string) => Promise<void>;
+  isRefreshing: boolean;
+};
+
+const HabitDataContext = createContext<HabitDataContextValue | undefined>(undefined);
+
+export function HabitDataProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<HabitDataState>({
+    status: "idle",
+    user: null,
+    dashboard: null,
+    tasks: null,
+    progression: null,
+  });
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const loadData = useCallback(async () => {
+    setState((previous) => ({ ...previous, status: "loading", errorMessage: undefined }));
+    try {
+      const users = await fetchUsers();
+      if (!users.length) {
+        throw new Error("Aucun utilisateur disponible dans la base de données.");
+      }
+
+      const user = users[0];
+      const [dashboard, tasks, progression] = await Promise.all([
+        fetchDashboard(user.id),
+        fetchTasks(user.id),
+        fetchProgression(user.id),
+      ]);
+
+      setState({
+        status: "ready",
+        errorMessage: undefined,
+        user,
+        dashboard,
+        tasks,
+        progression,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Impossible de charger les données distantes.";
+      setState((previous) => ({
+        ...previous,
+        status: "error",
+        errorMessage: message,
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const refresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await loadData();
+    setIsRefreshing(false);
+  }, [loadData]);
+
+  const completeTask = useCallback(
+    async (taskId: string) => {
+      if (!state.user) {
+        throw new Error("Utilisateur non chargé");
+      }
+      await completeTaskLog(state.user.id, taskId);
+      await refresh();
+    },
+    [refresh, state.user],
+  );
+
+  const value = useMemo<HabitDataContextValue>(
+    () => ({
+      state,
+      refresh,
+      completeTask,
+      isRefreshing,
+    }),
+    [state, refresh, completeTask, isRefreshing],
+  );
+
+  return <HabitDataContext.Provider value={value}>{children}</HabitDataContext.Provider>;
+}
+
+export function useHabitData(): HabitDataContextValue {
+  const context = useContext(HabitDataContext);
+  if (!context) {
+    throw new Error("useHabitData doit être utilisé à l'intérieur d'un HabitDataProvider");
+  }
+  return context;
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,59 @@
+import type {
+  DashboardResponse,
+  ProgressionResponse,
+  TaskListResponse,
+  UserSummary,
+} from "../types/api";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://127.0.0.1:8000";
+
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || "Erreur inattendue de l'API");
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchUsers(): Promise<UserSummary[]> {
+  const response = await fetch(`${API_URL}/users`);
+  return handleResponse<UserSummary[]>(response);
+}
+
+export async function fetchDashboard(userId: string): Promise<DashboardResponse> {
+  const response = await fetch(`${API_URL}/users/${userId}/dashboard`);
+  return handleResponse<DashboardResponse>(response);
+}
+
+export async function fetchTasks(userId: string): Promise<TaskListResponse> {
+  const response = await fetch(`${API_URL}/users/${userId}/tasks`);
+  return handleResponse<TaskListResponse>(response);
+}
+
+export async function fetchProgression(
+  userId: string,
+): Promise<ProgressionResponse> {
+  const response = await fetch(`${API_URL}/users/${userId}/progression`);
+  return handleResponse<ProgressionResponse>(response);
+}
+
+export async function completeTaskLog(
+  userId: string,
+  userTaskId: string,
+): Promise<void> {
+  const response = await fetch(`${API_URL}/task-logs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      user_id: userId,
+      user_task_id: userTaskId,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || "Impossible d'enregistrer la complétion de la tâche");
+  }
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,75 @@
+export type UserSummary = {
+  id: string;
+  display_name: string;
+};
+
+export type DashboardDomainStat = {
+  domain_id: number;
+  domain_key: string;
+  domain_name: string;
+  icon: string | null;
+  weekly_points: number;
+  weekly_target: number;
+  weekly_xp: number;
+  progress_ratio: number;
+};
+
+export type DashboardResponse = {
+  user_id: string;
+  display_name: string;
+  initials: string;
+  level: number;
+  current_xp: number;
+  xp_to_next: number;
+  domain_stats: DashboardDomainStat[];
+};
+
+export type TaskListItem = {
+  id: string;
+  title: string;
+  domain_id: number;
+  domain_key: string;
+  domain_name: string;
+  icon: string | null;
+  xp: number;
+  completed_today: boolean;
+};
+
+export type TaskListResponse = {
+  user_id: string;
+  tasks: TaskListItem[];
+};
+
+export type HistoryItem = {
+  id: string;
+  title: string;
+  occurred_at: string;
+  xp_awarded: number;
+  domain_id: number;
+  domain_key: string;
+  domain_name: string;
+  icon: string | null;
+};
+
+export type WeeklyStat = {
+  domain_id: number;
+  domain_key: string;
+  domain_name: string;
+  icon: string | null;
+  weekly_points: number;
+  weekly_xp: number;
+};
+
+export type BadgeItem = {
+  id: string;
+  title: string;
+  subtitle: string;
+  domain_id: number | null;
+};
+
+export type ProgressionResponse = {
+  user_id: string;
+  recent_history: HistoryItem[];
+  weekly_stats: WeeklyStat[];
+  badges: BadgeItem[];
+};


### PR DESCRIPTION
## Summary
- add user-focused FastAPI endpoints to expose dashboard, task list, and progression data
- create a shared habit data provider and API client utilities for loading backend state in the app
- refresh home, quests, and progression screens to render live database content with proper loading and error handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de6de5cff48327bab68a531c82c8ce