### PR TITLE
Fix auth response serialization for login and registration

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -62,7 +62,7 @@ def register_user(
     session.commit()
     session.refresh(user)
 
-    return AuthResponse(user=UserSummary.model_validate(user))
+    return AuthResponse(user=UserSummary.model_validate(user, from_attributes=True))
 
 
 @router.post("/login", response_model=AuthResponse)
@@ -78,4 +78,4 @@ def login_user(
             detail="Identifiants de connexion invalides.",
         )
 
-    return AuthResponse(user=UserSummary.model_validate(user))
+    return AuthResponse(user=UserSummary.model_validate(user, from_attributes=True))

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from ..database import get_session
 from ..models import User
-from ..schemas import AuthResponse, LoginRequest, RegisterRequest
+from ..schemas import AuthResponse, LoginRequest, RegisterRequest, UserSummary
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -62,7 +62,7 @@ def register_user(
     session.commit()
     session.refresh(user)
 
-    return AuthResponse(user=user)
+    return AuthResponse(user=UserSummary.model_validate(user))
 
 
 @router.post("/login", response_model=AuthResponse)
@@ -78,4 +78,4 @@ def login_user(
             detail="Identifiants de connexion invalides.",
         )
 
-    return AuthResponse(user=user)
+    return AuthResponse(user=UserSummary.model_validate(user))


### PR DESCRIPTION
## Summary
- ensure AuthResponse payloads validate SQLAlchemy users through the UserSummary schema

## Testing
- make check

------
https://chatgpt.com/codex/tasks/task_e_68de8ee4f8808327b433b6f5b5417ed0