### PR TITLE
Use domain stats from API on dashboard

### DIFF
--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -12,7 +12,6 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import BottomNav from "../components/BottomNav";
-import { CATEGORIES, CATEGORY_OPTIONS } from "../constants/categories";
 import { useAuth } from "../context/AuthContext";
 import { useHabitData } from "../context/HabitDataContext";
 
@@ -70,28 +69,17 @@ export default function Index() {
       return null;
     }
 
-    const statsByKey = new Map(
-      dashboard.domain_stats.map((stat) => [stat.domain_key, stat]),
-    );
-    const orderedStats = CATEGORY_OPTIONS.map((key, index) => {
-      const stat = statsByKey.get(key);
-      if (stat) {
-        statsByKey.delete(key);
-        return stat;
-      }
-      const category = CATEGORIES[key];
-      return {
-        domain_id: -(index + 1),
-        domain_key: key,
-        domain_name: category.label,
-        icon: category.icon,
-        weekly_points: 0,
-        weekly_target: 0,
-        weekly_xp: 0,
-        progress_ratio: 0,
-      };
-    });
-    const statsToDisplay = [...orderedStats, ...statsByKey.values()];
+    const statsToDisplay = dashboard.domain_stats;
+
+    if (statsToDisplay.length === 0) {
+      return (
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorLabel}>
+            Aucun domaine actif n'est configuré pour votre compte.
+          </Text>
+        </View>
+      );
+    }
 
     return (
       <>


### PR DESCRIPTION
## Summary
- remove the fallback on hard-coded category definitions for the dashboard
- rely entirely on the domain statistics returned by the API to render dashboard rows
- show an informational message when no domain is configured for the user

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec23bb5e08327ad7fc819bd9f481f