### PR TITLE
Refine progression screen styling

### DIFF
--- a/frontend/app/progression.tsx
+++ b/frontend/app/progression.tsx
@@ -12,6 +12,7 @@ import {
 } from "react-native";
 
 import { SafeAreaView } from "react-native-safe-area-context";
+import { LinearGradient } from "expo-linear-gradient";
 import BottomNav from "../components/BottomNav";
 import { CATEGORIES, type CategoryKey } from "../constants/categories";
 import { useAuth } from "../context/AuthContext";
@@ -90,112 +91,123 @@ export default function ProgressionScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <View style={styles.screen}>
-        <FlatList
-          data={[]}
-          keyExtractor={(_, index) => index.toString()}
-          renderItem={() => null}
-          contentContainerStyle={styles.listContent}
-          refreshControl={
-            <RefreshControl refreshing={isRefreshing} onRefresh={() => refresh()} tintColor="#58a6ff" />
-          }
-          ListHeaderComponent={
-            <>
-              <View style={styles.headerRow}>
-                <Pressable accessibilityRole="button" onPress={() => router.push("/")} style={styles.backButton}>
-                  <Feather name="chevron-left" size={22} color="#e5e7eb" />
-                </Pressable>
-                <Text style={styles.headerTitle}>Ma Progression</Text>
-              </View>
-              <Text style={styles.headerSubtitle}>
-                Suivez l’impact de vos habitudes et découvrez les récompenses débloquées.
-              </Text>
+    <LinearGradient colors={["#111827", "#111827", "#1f2937"]} style={styles.gradient}>
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.screen}>
+          <FlatList
+            data={[]}
+            keyExtractor={(_, index) => index.toString()}
+            renderItem={() => null}
+            contentContainerStyle={styles.listContent}
+            refreshControl={
+              <RefreshControl refreshing={isRefreshing} onRefresh={() => refresh()} tintColor="#58a6ff" />
+            }
+            ListHeaderComponent={
+              <>
+                <View style={styles.headerRow}>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => router.push("/")}
+                    style={styles.backButton}
+                  >
+                    <Feather name="chevron-left" size={22} color="#e5e7eb" />
+                  </Pressable>
+                  <Text style={styles.headerTitle}>Ma Progression</Text>
+                </View>
+                <Text style={styles.headerSubtitle}>
+                  Suivez l’impact de vos habitudes et découvrez les récompenses débloquées.
+                </Text>
 
-              <View style={styles.card}>
-                <Text style={styles.cardTitle}>Historique récent</Text>
-                {historyItems.length === 0 ? (
-                  <Text style={styles.emptyText}>Aucun log enregistré récemment.</Text>
-                ) : (
-                  historyItems.map((item) => {
-                    const category = CATEGORIES[item.domain_key as CategoryKey] ?? null;
-                    const icon = item.icon ?? category?.icon ?? "⭐";
-                    return (
-                      <View key={item.id} style={styles.historyItem}>
-                        <Text style={styles.historyIcon}>{icon}</Text>
-                        <View style={styles.historyContent}>
-                          <Text style={styles.historyAction}>{item.title}</Text>
-                          <Text style={styles.historyDate}>{formatHistoryDate(item.occurred_at)}</Text>
-                        </View>
-                        <Text style={styles.historyXp}>+{item.xp_awarded} XP</Text>
-                      </View>
-                    );
-                  })
-                )}
-              </View>
-
-              <View style={styles.card}>
-                <Text style={styles.cardTitle}>Statistiques hebdo</Text>
-                {weeklyStats.length === 0 ? (
-                  <Text style={styles.emptyText}>Aucune donnée pour cette semaine.</Text>
-                ) : (
-                  <View style={styles.statsGrid}>
-                    {weeklyStats.map((stat) => {
-                      const category = CATEGORIES[stat.domain_key as CategoryKey] ?? null;
-                      const icon = stat.icon ?? category?.icon ?? "📈";
-                      const label = category?.label ?? stat.domain_name;
+                <View style={styles.card}>
+                  <Text style={styles.cardTitle}>Historique récent</Text>
+                  {historyItems.length === 0 ? (
+                    <Text style={styles.emptyText}>Aucun log enregistré récemment.</Text>
+                  ) : (
+                    historyItems.map((item) => {
+                      const category = CATEGORIES[item.domain_key as CategoryKey] ?? null;
+                      const icon = item.icon ?? category?.icon ?? "⭐";
                       return (
-                        <View key={stat.domain_id} style={styles.statCard}>
-                          <Text style={styles.statIcon}>{icon}</Text>
-                          <Text style={styles.statLabel}>{label}</Text>
-                          <Text style={styles.statHighlight}>+{stat.weekly_xp} XP</Text>
-                          <Text style={styles.statSubHighlight}>{stat.weekly_points} pts</Text>
+                        <View key={item.id} style={styles.historyItem}>
+                          <View style={styles.historyIconWrapper}>
+                            <Text style={styles.historyIcon}>{icon}</Text>
+                          </View>
+                          <View style={styles.historyContent}>
+                            <Text style={styles.historyAction}>{item.title}</Text>
+                            <Text style={styles.historyDate}>{formatHistoryDate(item.occurred_at)}</Text>
+                          </View>
+                          <Text style={styles.historyXp}>+{item.xp_awarded} XP</Text>
                         </View>
                       );
-                    })}
-                  </View>
-                )}
-              </View>
+                    })
+                  )}
+                </View>
 
-              <View style={styles.badgeCard}>
-                <Text style={styles.badgeCardTitle}>Badges débloqués</Text>
-                {badges.length === 0 ? (
-                  <Text style={styles.emptyText}>Continuez à progresser pour débloquer vos premiers badges !</Text>
-                ) : (
-                  badges.map((badge) => (
-                    <View key={badge.id} style={styles.badgeRow}>
-                      <Text style={styles.badgeIcon}>🏆</Text>
-                      <View style={styles.badgeContent}>
-                        <Text style={styles.badgeTitle}>{badge.title}</Text>
-                        <Text style={styles.badgeSubtitle}>{badge.subtitle}</Text>
-                      </View>
+                <View style={styles.card}>
+                  <Text style={styles.cardTitle}>Statistiques hebdo</Text>
+                  {weeklyStats.length === 0 ? (
+                    <Text style={styles.emptyText}>Aucune donnée pour cette semaine.</Text>
+                  ) : (
+                    <View style={styles.statsGrid}>
+                      {weeklyStats.map((stat) => {
+                        const category = CATEGORIES[stat.domain_key as CategoryKey] ?? null;
+                        const icon = stat.icon ?? category?.icon ?? "📈";
+                        const label = category?.label ?? stat.domain_name;
+                        return (
+                          <View key={stat.domain_id} style={styles.statCard}>
+                            <Text style={styles.statIcon}>{icon}</Text>
+                            <Text style={styles.statLabel}>{label}</Text>
+                            <Text style={styles.statHighlight}>+{stat.weekly_xp} XP</Text>
+                            <Text style={styles.statSubHighlight}>{stat.weekly_points} pts</Text>
+                          </View>
+                        );
+                      })}
                     </View>
-                  ))
-                )}
-              </View>
-            </>
-          }
-        />
-        <BottomNav />
-      </View>
-    </SafeAreaView>
+                  )}
+                </View>
+
+                <View style={styles.badgeCard}>
+                  <Text style={styles.badgeCardTitle}>Badges débloqués</Text>
+                  {badges.length === 0 ? (
+                    <Text style={styles.emptyText}>Continuez à progresser pour débloquer vos premiers badges !</Text>
+                  ) : (
+                    badges.map((badge) => (
+                      <View key={badge.id} style={styles.badgeRow}>
+                        <Text style={styles.badgeIcon}>🏆</Text>
+                        <View style={styles.badgeContent}>
+                          <Text style={styles.badgeTitle}>{badge.title}</Text>
+                          <Text style={styles.badgeSubtitle}>{badge.subtitle}</Text>
+                        </View>
+                      </View>
+                    ))
+                  )}
+                </View>
+              </>
+            }
+          />
+          <BottomNav />
+        </View>
+      </SafeAreaView>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
+  gradient: {
+    flex: 1,
+  },
   safeArea: {
     flex: 1,
-    backgroundColor: "#0f172a",
+    backgroundColor: "transparent",
   },
   screen: {
     flex: 1,
-    backgroundColor: "#0f172a",
+    backgroundColor: "transparent",
   },
   listContent: {
     paddingHorizontal: 24,
     paddingBottom: 140,
     paddingTop: 28,
-    gap: 20,
+    gap: 24,
   },
   headerRow: {
     flexDirection: "row",
@@ -213,101 +225,113 @@ const styles = StyleSheet.create({
     borderColor: "rgba(148, 163, 184, 0.25)",
   },
   headerTitle: {
-    color: "#e2e8f0",
-    fontSize: 22,
+    color: "#f3f4f6",
+    fontSize: 24,
     fontWeight: "700",
   },
   headerSubtitle: {
-    color: "#94a3b8",
+    color: "#9ca3af",
     fontSize: 15,
+    marginTop: 8,
   },
   card: {
-    backgroundColor: "rgba(30, 41, 59, 0.65)",
-    borderColor: "rgba(75, 85, 99, 0.45)",
+    backgroundColor: "rgba(31, 41, 55, 0.7)",
+    borderColor: "rgba(75, 85, 99, 0.35)",
     borderWidth: 1,
-    borderRadius: 20,
-    padding: 20,
-    gap: 16,
+    borderRadius: 24,
+    padding: 22,
+    gap: 18,
   },
   cardTitle: {
-    color: "#e2e8f0",
+    color: "#c4b5fd",
     fontSize: 18,
     fontWeight: "700",
   },
   statsGrid: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 12,
+    gap: 14,
   },
   statCard: {
     flexBasis: "48%",
-    backgroundColor: "rgba(15, 23, 42, 0.65)",
-    borderRadius: 16,
+    backgroundColor: "rgba(17, 24, 39, 0.6)",
+    borderRadius: 18,
     borderWidth: 1,
-    borderColor: "rgba(59, 130, 246, 0.25)",
+    borderColor: "rgba(147, 197, 253, 0.2)",
     padding: 16,
-    gap: 8,
+    gap: 6,
   },
   statIcon: {
-    fontSize: 24,
+    fontSize: 26,
   },
   statLabel: {
-    color: "#e2e8f0",
-    fontSize: 16,
+    color: "#e5e7eb",
+    fontSize: 14,
     fontWeight: "600",
   },
   statHighlight: {
     color: "#34d399",
-    fontSize: 15,
-    fontWeight: "600",
+    fontSize: 16,
+    fontWeight: "700",
   },
   statSubHighlight: {
     color: "#94a3b8",
-    fontSize: 13,
+    fontSize: 12,
   },
   badgeCard: {
-    backgroundColor: "rgba(15, 23, 42, 0.85)",
-    borderColor: "rgba(59, 130, 246, 0.3)",
+    backgroundColor: "rgba(251, 191, 36, 0.08)",
+    borderColor: "rgba(252, 211, 77, 0.35)",
     borderWidth: 1,
-    borderRadius: 20,
-    padding: 20,
-    gap: 16,
+    borderRadius: 24,
+    padding: 22,
+    gap: 18,
   },
   badgeCardTitle: {
-    color: "#f8fafc",
+    color: "#fcd34d",
     fontSize: 18,
     fontWeight: "700",
   },
   badgeRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
+    gap: 14,
+    backgroundColor: "rgba(17, 24, 39, 0.35)",
+    borderRadius: 18,
+    padding: 16,
   },
   badgeIcon: {
-    fontSize: 28,
+    fontSize: 30,
   },
   badgeContent: {
     flex: 1,
     gap: 4,
   },
   badgeTitle: {
-    color: "#f9fafb",
+    color: "#fef3c7",
     fontSize: 16,
-    fontWeight: "600",
+    fontWeight: "700",
   },
   badgeSubtitle: {
-    color: "#cbd5f5",
-    fontSize: 14,
+    color: "#facc15",
+    fontSize: 13,
   },
   historyItem: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 16,
-    backgroundColor: "rgba(15, 23, 42, 0.65)",
+    gap: 18,
+    backgroundColor: "rgba(15, 23, 42, 0.55)",
     borderWidth: 1,
-    borderColor: "rgba(75, 85, 99, 0.35)",
+    borderColor: "rgba(148, 163, 184, 0.2)",
     borderRadius: 20,
     padding: 18,
+  },
+  historyIconWrapper: {
+    width: 44,
+    height: 44,
+    borderRadius: 14,
+    backgroundColor: "rgba(17, 24, 39, 0.75)",
+    alignItems: "center",
+    justifyContent: "center",
   },
   historyIcon: {
     fontSize: 24,
@@ -322,16 +346,16 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
   historyDate: {
-    color: "#94a3b8",
+    color: "#9ca3af",
     fontSize: 13,
   },
   historyXp: {
-    color: "#facc15",
+    color: "#a855f7",
     fontSize: 15,
     fontWeight: "700",
   },
   emptyText: {
-    color: "#cbd5f5",
+    color: "#d1d5db",
     fontSize: 15,
     textAlign: "center",
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.8",
     "expo-linking": "~8.0.8",
+    "expo-linear-gradient": "~13.0.2",
     "expo-router": "~6.0.10",
     "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",


### PR DESCRIPTION
## Summary
- add a gradient-backed layout and refreshed cards on the progression screen to mirror the desired design
- enhance history, stats, and badge sections with updated colors and icon treatments
- include expo-linear-gradient to support the new background gradient

## Testing
- npm run lint *(fails: expo CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e12c9e12c483279d75df6edafe3054