### PR TITLE
Revamp quests screen to match updated daily quests design

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.8",
     "expo-linking": "~8.0.8",
+    "expo-linear-gradient": "~13.0.2",
     "expo-router": "~6.0.10",
     "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",


### PR DESCRIPTION
## Summary
- restyle the quests screen with a gradient layout, refreshed cards, and inline task creation to match the new design guidance
- swap the modal add flow for an inline form with category selectors and gradients for the call-to-action buttons
- add expo-linear-gradient to support the new gradient background and button styling

## Testing
- npm run lint *(fails: expo CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e12cc1815c83279dcfc2062ec2bb48