### PR TITLE
Add customizable avatars to dashboard and profile

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -160,6 +160,7 @@ def serialize_user_profile(user: User, settings: UserSettings) -> UserProfile:
         language=settings.language,
         notifications_enabled=settings.notifications_enabled,
         first_day_of_week=settings.first_day_of_week,
+        avatar_type=settings.avatar_type,
     )
 
 
@@ -270,6 +271,7 @@ def update_user_profile(
     settings.language = payload.language.strip() or settings.language
     settings.notifications_enabled = payload.notifications_enabled
     settings.first_day_of_week = payload.first_day_of_week
+    settings.avatar_type = payload.avatar_type.value
 
     session.commit()
     session.refresh(user)
@@ -286,6 +288,7 @@ def list_users(session: Session = Depends(get_db_session)) -> list[UserSummary]:
 @router.get("/{user_id}/dashboard", response_model=DashboardResponse)
 def get_dashboard(user_id: UUID, session: Session = Depends(get_db_session)) -> DashboardResponse:
     user = resolve_user(session, user_id)
+    settings = ensure_user_settings(session, user)
 
     level = session.get(UserLevel, user_id)
     if level:
@@ -384,6 +387,7 @@ def get_dashboard(user_id: UUID, session: Session = Depends(get_db_session)) -> 
         level=current_level,
         current_xp=current_xp,
         xp_to_next=xp_to_next,
+        avatar_type=settings.avatar_type,
         domain_stats=domain_stats,
     )
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -409,6 +409,7 @@ class UserSettings(Base):
     language: Mapped[str] = mapped_column(String(10), nullable=False, default="fr")
     notifications_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     first_day_of_week: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    avatar_type: Mapped[str] = mapped_column(String(30), nullable=False, default="explorateur")
 
     user: Mapped[User] = relationship("User", back_populates="user_settings")
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
@@ -8,6 +9,13 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 from .models import ChallengeStatus, SnapshotPeriod, SourceType
+
+
+class AvatarType(str, enum.Enum):
+    EXPLORATEUR = "explorateur"
+    BATISSEUR = "batisseur"
+    MOINE = "moine"
+    GUERRIER = "guerrier"
 
 
 class DomainBase(BaseModel):
@@ -168,6 +176,7 @@ class DashboardResponse(BaseModel):
     level: int
     current_xp: int
     xp_to_next: int
+    avatar_type: AvatarType
     domain_stats: list[DashboardDomainStat]
 
 
@@ -266,6 +275,7 @@ class UserProfile(BaseModel):
     language: str = Field(min_length=2, max_length=10)
     notifications_enabled: bool
     first_day_of_week: int = Field(ge=0, le=6)
+    avatar_type: AvatarType
 
 
 class UserProfileUpdateRequest(UserProfile):

--- a/backend/migrations/versions/20250219_000001_add_avatar_type_to_user_settings.py
+++ b/backend/migrations/versions/20250219_000001_add_avatar_type_to_user_settings.py
@@ -1,0 +1,23 @@
+"""Add avatar type to user settings."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20250219_000001"
+down_revision = "ff8fed6a9f28"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_settings",
+        sa.Column("avatar_type", sa.String(length=30), nullable=False, server_default="explorateur"),
+    )
+    op.alter_column("user_settings", "avatar_type", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "avatar_type")

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,4 +1,5 @@
 import { Feather } from "@expo/vector-icons";
+import { Image } from "expo-image";
 import { Redirect, useRootNavigationState, useRouter } from "expo-router";
 import {
   ActivityIndicator,
@@ -12,6 +13,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import BottomNav from "../components/BottomNav";
+import { getAvatarAsset } from "../constants/avatarAssets";
+import { getAvatarOption } from "../constants/avatarTypes";
 import { useAuth } from "../context/AuthContext";
 import { useHabitData } from "../context/HabitDataContext";
 
@@ -67,12 +70,16 @@ export default function Index() {
     }
 
     const statsToDisplay = dashboard.domain_stats;
+    const avatarOption = getAvatarOption(dashboard.avatar_type);
+    const avatarSource = getAvatarAsset(dashboard.avatar_type, dashboard.level);
+    const avatarBackground = avatarOption.colors[0] ?? "#1f2937";
+    const avatarAccent = avatarOption.colors[1] ?? "#38bdf8";
 
     if (statsToDisplay.length === 0) {
       return (
         <View style={styles.loadingContainer}>
           <Text style={styles.errorLabel}>
-            Aucun domaine actif n'est configuré pour votre compte.
+            Aucun domaine actif n’est configuré pour votre compte.
           </Text>
         </View>
       );
@@ -81,11 +88,19 @@ export default function Index() {
     return (
       <>
         <View style={styles.avatarContainer}>
-          <View style={styles.avatar}>
-            <Text style={styles.avatarInitials}>{dashboard.initials}</Text>
+          <View style={[styles.avatar, { backgroundColor: avatarBackground, borderColor: avatarAccent }]}>
+            {avatarSource ? (
+              <Image source={avatarSource} style={styles.avatarImage} contentFit="contain" />
+            ) : (
+              <Text style={styles.avatarInitials}>{dashboard.initials}</Text>
+            )}
           </View>
-          <View>
+          <View style={styles.avatarDetails}>
             <Text style={styles.displayName}>{dashboard.display_name}</Text>
+            <Text style={[styles.avatarType, { color: avatarAccent }]}>{avatarOption.label}</Text>
+            {avatarOption.tagline ? (
+              <Text style={styles.avatarTagline}>{avatarOption.tagline}</Text>
+            ) : null}
             <Text style={styles.levelLabel}>Niveau {dashboard.level}</Text>
             <Text style={styles.xpText}>
               {dashboard.current_xp} XP / {dashboard.xp_to_next} XP
@@ -238,20 +253,40 @@ const styles = StyleSheet.create({
     width: 72,
     height: 72,
     borderRadius: 36,
-    backgroundColor: "#1f6feb",
     alignItems: "center",
     justifyContent: "center",
+    borderWidth: 2,
+    borderColor: "#1f6feb",
+    overflow: "hidden",
+  },
+  avatarImage: {
+    width: "100%",
+    height: "100%",
   },
   avatarInitials: {
     color: "white",
     fontSize: 26,
     fontWeight: "700",
   },
+  avatarDetails: {
+    flex: 1,
+    gap: 4,
+  },
   displayName: {
     color: "#f8fafc",
     fontSize: 18,
     fontWeight: "700",
-    marginBottom: 4,
+  },
+  avatarType: {
+    color: "#94a3b8",
+    fontSize: 12,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  avatarTagline: {
+    color: "#94a3b8",
+    fontSize: 12,
   },
   levelLabel: {
     color: "white",

--- a/frontend/app/settings/objectifs.tsx
+++ b/frontend/app/settings/objectifs.tsx
@@ -154,7 +154,7 @@ export default function ObjectivesScreen() {
       const message =
         error instanceof Error
           ? error.message
-          : "Impossible d'enregistrer vos objectifs pour le moment.";
+          : "Impossible d’enregistrer vos objectifs pour le moment.";
       Alert.alert("Erreur", message);
     } finally {
       setIsSaving(false);
@@ -185,7 +185,7 @@ export default function ObjectivesScreen() {
     if (settings.length === 0) {
       return (
         <View style={styles.loadingContainer}>
-          <Text style={styles.errorLabel}>Aucun domaine n'est disponible pour votre compte.</Text>
+          <Text style={styles.errorLabel}>Aucun domaine n’est disponible pour votre compte.</Text>
         </View>
       );
     }
@@ -194,7 +194,7 @@ export default function ObjectivesScreen() {
       <View style={styles.formContainer}>
         <Text style={styles.introText}>
           Activez les domaines que vous souhaitez suivre et définissez un objectif de points
-          hebdomadaire pour chacun d'entre eux.
+          hebdomadaire pour chacun d’entre eux.
         </Text>
 
         {settings.map((item) => (

--- a/frontend/app/settings/profile.tsx
+++ b/frontend/app/settings/profile.tsx
@@ -1,4 +1,5 @@
 import { Feather } from "@expo/vector-icons";
+import { Image } from "expo-image";
 import { useRootNavigationState, useRouter } from "expo-router";
 import { useCallback, useEffect, useState } from "react";
 import {
@@ -15,9 +16,12 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import BottomNav from "../../components/BottomNav";
+import { getAvatarAsset } from "../../constants/avatarAssets";
+import { AVATAR_OPTIONS } from "../../constants/avatarTypes";
 import { useAuth } from "../../context/AuthContext";
 import { useHabitData } from "../../context/HabitDataContext";
 import { fetchUserProfile, updateUserProfile } from "../../lib/api";
+import type { AvatarType } from "../../types/api";
 
 
 type ProfileFormState = {
@@ -27,6 +31,7 @@ type ProfileFormState = {
   language: string;
   notificationsEnabled: boolean;
   firstDayOfWeek: string;
+  avatarType: AvatarType;
 };
 
 const INITIAL_FORM: ProfileFormState = {
@@ -36,6 +41,7 @@ const INITIAL_FORM: ProfileFormState = {
   language: "fr",
   notificationsEnabled: true,
   firstDayOfWeek: "1",
+  avatarType: "explorateur",
 };
 
 export default function ProfileScreen() {
@@ -46,7 +52,7 @@ export default function ProfileScreen() {
     updateUser,
   } = useAuth();
   const {
-    state: { user },
+    state: { user, dashboard },
     refresh,
   } = useHabitData();
 
@@ -54,6 +60,7 @@ export default function ProfileScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const avatarPreviewLevel = dashboard?.level ?? 1;
 
   useEffect(() => {
     if (!navigationState?.key) {
@@ -80,6 +87,7 @@ export default function ProfileScreen() {
         language: response.language,
         notificationsEnabled: response.notifications_enabled,
         firstDayOfWeek: String(response.first_day_of_week ?? 1),
+        avatarType: response.avatar_type,
       });
     } catch (error) {
       const message =
@@ -109,7 +117,7 @@ export default function ProfileScreen() {
 
     const trimmedName = form.displayName.trim();
     if (!trimmedName) {
-      Alert.alert("Nom requis", "Veuillez indiquer un nom d'affichage valide.");
+      Alert.alert("Nom requis", "Veuillez indiquer un nom d’affichage valide.");
       return;
     }
 
@@ -131,6 +139,7 @@ export default function ProfileScreen() {
         language: form.language.trim() || "fr",
         notifications_enabled: form.notificationsEnabled,
         first_day_of_week: firstDay,
+        avatar_type: form.avatarType,
       };
       const response = await updateUserProfile(user.id, payload);
       setForm({
@@ -140,6 +149,7 @@ export default function ProfileScreen() {
         language: response.language,
         notificationsEnabled: response.notifications_enabled,
         firstDayOfWeek: String(response.first_day_of_week ?? firstDay),
+        avatarType: response.avatar_type,
       });
       if (authUser) {
         updateUser({ id: authUser.id, display_name: response.display_name });
@@ -150,7 +160,7 @@ export default function ProfileScreen() {
       const message =
         error instanceof Error
           ? error.message
-          : "Impossible d'enregistrer votre profil pour le moment.";
+          : "Impossible d’enregistrer votre profil pour le moment.";
       Alert.alert("Erreur", message);
     } finally {
       setIsSaving(false);
@@ -180,10 +190,64 @@ export default function ProfileScreen() {
 
     return (
       <View style={styles.formContainer}>
+        <Text style={styles.sectionTitle}>Avatar</Text>
+        <Text style={styles.sectionSubtitle}>
+          Choisissez le type d’avatar qui vous représente. Son apparence évoluera avec vos niveaux.
+        </Text>
+
+        <View style={styles.avatarOptionsGrid}>
+          {AVATAR_OPTIONS.map((option) => {
+            const isSelected = option.type === form.avatarType;
+            const preview = getAvatarAsset(option.type, avatarPreviewLevel);
+            const accentColor = option.colors[1] ?? "#38bdf8";
+            const previewBackground = option.colors[0] ?? "#0f172a";
+            const cardBackground = isSelected ? "#0f172a" : "#161b22";
+            const borderColor = isSelected ? accentColor : "#1f2937";
+            const initials = option.label
+              .split(" ")
+              .map((part) => part[0] ?? "")
+              .join("")
+              .slice(0, 2)
+              .toUpperCase();
+            return (
+              <TouchableOpacity
+                key={option.type}
+                style={[
+                  styles.avatarOption,
+                  isSelected ? styles.avatarOptionSelected : null,
+                  { backgroundColor: cardBackground, borderColor },
+                ]}
+                onPress={() => handleChange("avatarType", option.type)}
+                activeOpacity={0.85}
+              >
+                <View
+                  style={[
+                    styles.avatarOptionPreview,
+                    { borderColor: accentColor, backgroundColor: previewBackground },
+                  ]}
+                >
+                  {preview ? (
+                    <Image source={preview} style={styles.avatarOptionImage} contentFit="contain" />
+                  ) : (
+                    <Text style={styles.avatarOptionInitials}>{initials}</Text>
+                  )}
+                </View>
+                <View style={styles.avatarOptionTextGroup}>
+                  <Text style={styles.avatarOptionLabel}>{option.label}</Text>
+                  <Text style={styles.avatarOptionTagline}>{option.tagline}</Text>
+                  <Text style={styles.avatarOptionEvolution}>
+                    Évolution: {option.evolution.join(" → ")}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
         <Text style={styles.sectionTitle}>Informations générales</Text>
 
         <View style={styles.inputGroup}>
-          <Text style={styles.inputLabel}>Nom d'affichage</Text>
+          <Text style={styles.inputLabel}>Nom d’affichage</Text>
           <TextInput
             style={styles.input}
             value={form.displayName}
@@ -380,6 +444,68 @@ const styles = StyleSheet.create({
     color: "#f1f5f9",
     fontSize: 18,
     fontWeight: "700",
+  },
+  sectionSubtitle: {
+    color: "#94a3b8",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  avatarOptionsGrid: {
+    gap: 16,
+  },
+  avatarOption: {
+    flexDirection: "row",
+    gap: 16,
+    alignItems: "center",
+    backgroundColor: "#161b22",
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    padding: 16,
+  },
+  avatarOptionSelected: {
+    shadowColor: "#38bdf8",
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.35,
+    shadowRadius: 10,
+    elevation: 6,
+  },
+  avatarOptionPreview: {
+    width: 60,
+    height: 60,
+    borderRadius: 16,
+    borderWidth: 2,
+    borderColor: "#1f6feb",
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+    backgroundColor: "#0f172a",
+  },
+  avatarOptionImage: {
+    width: "100%",
+    height: "100%",
+  },
+  avatarOptionInitials: {
+    color: "#f8fafc",
+    fontSize: 20,
+    fontWeight: "700",
+  },
+  avatarOptionTextGroup: {
+    flex: 1,
+    gap: 4,
+  },
+  avatarOptionLabel: {
+    color: "#f1f5f9",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  avatarOptionTagline: {
+    color: "#94a3b8",
+    fontSize: 13,
+  },
+  avatarOptionEvolution: {
+    color: "#64748b",
+    fontSize: 12,
   },
   inputGroup: {
     gap: 8,

--- a/frontend/constants/avatarAssets.ts
+++ b/frontend/constants/avatarAssets.ts
@@ -1,0 +1,49 @@
+import type { ImageSourcePropType } from "react-native";
+
+import type { AvatarType } from "../types/api";
+
+const AVATAR_ASSETS: Record<AvatarType, Record<number, ImageSourcePropType>> = {
+  explorateur: {
+    1: require("../assets/explorateur-1.svg"),
+  },
+  batisseur: {
+    1: require("../assets/batisseur-1.svg"),
+  },
+  moine: {
+    1: require("../assets/moine-1.svg"),
+  },
+  guerrier: {
+    1: require("../assets/guerrier-1.svg"),
+  },
+};
+
+export function getAvatarAsset(type: AvatarType, level: number): ImageSourcePropType | null {
+  const assets = AVATAR_ASSETS[type];
+  if (!assets) {
+    return null;
+  }
+
+  const availableLevels = Object.keys(assets)
+    .map((value) => Number.parseInt(value, 10))
+    .filter((value) => !Number.isNaN(value))
+    .sort((a, b) => a - b);
+
+  for (let index = availableLevels.length - 1; index >= 0; index -= 1) {
+    const availableLevel = availableLevels[index];
+    if (level >= availableLevel) {
+      return assets[availableLevel];
+    }
+  }
+
+  return assets[availableLevels[0]] ?? null;
+}
+
+export const REGISTERED_AVATAR_LEVELS: Record<AvatarType, number[]> = Object.fromEntries(
+  (Object.keys(AVATAR_ASSETS) as AvatarType[]).map((type) => [
+    type,
+    Object.keys(AVATAR_ASSETS[type])
+      .map((value) => Number.parseInt(value, 10))
+      .filter((value) => !Number.isNaN(value))
+      .sort((a, b) => a - b),
+  ]),
+);

--- a/frontend/constants/avatarTypes.ts
+++ b/frontend/constants/avatarTypes.ts
@@ -1,0 +1,61 @@
+import type { AvatarType } from "../types/api";
+
+export type AvatarOption = {
+  type: AvatarType;
+  label: string;
+  tagline: string;
+  evolution: string[];
+  colors: string[];
+};
+
+export const AVATAR_OPTIONS: AvatarOption[] = [
+  {
+    type: "explorateur",
+    label: "Explorateur",
+    tagline: "Aventure • Découverte",
+    evolution: ["Sac à dos", "Boussole", "Lampe", "Carte détaillée"],
+    colors: ["#3a2f1d", "#2f5f3d", "#c79a2f"],
+  },
+  {
+    type: "batisseur",
+    label: "Bâtisseur",
+    tagline: "Discipline • Construction",
+    evolution: ["Marteau", "Établi", "Plan", "Tour solide"],
+    colors: ["#4a5568", "#1e3a8a", "#94a3b8"],
+  },
+  {
+    type: "moine",
+    label: "Moine",
+    tagline: "Calme • Sérénité",
+    evolution: ["Robe simple", "Bâton", "Aura", "Halo lumineux"],
+    colors: ["#f5e0c3", "#7c3aed", "#f8fafc"],
+  },
+  {
+    type: "guerrier",
+    label: "Guerrier",
+    tagline: "Résilience • Force",
+    evolution: ["Tenue simple", "Brassard", "Armure légère", "Aura puissante"],
+    colors: ["#991b1b", "#111827", "#d1d5db"],
+  },
+];
+
+export const AVATAR_TYPE_LABELS: Record<AvatarType, string> = AVATAR_OPTIONS.reduce(
+  (accumulator, option) => {
+    accumulator[option.type] = option.label;
+    return accumulator;
+  },
+  {} as Record<AvatarType, string>,
+);
+
+export function getAvatarOption(type: AvatarType): AvatarOption {
+  const option = AVATAR_OPTIONS.find((item) => item.type === type);
+  return (
+    option ?? {
+      type,
+      label: type,
+      tagline: "",
+      evolution: [],
+      colors: [],
+    }
+  );
+}

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -31,6 +31,7 @@ export type DashboardResponse = {
   level: number;
   current_xp: number;
   xp_to_next: number;
+  avatar_type: AvatarType;
   domain_stats: DashboardDomainStat[];
 };
 
@@ -120,6 +121,8 @@ export type UpdateUserDomainSettingsRequest = {
   }[];
 };
 
+export type AvatarType = "explorateur" | "batisseur" | "moine" | "guerrier";
+
 export type UserProfile = {
   display_name: string;
   email: string;
@@ -127,6 +130,7 @@ export type UserProfile = {
   language: string;
   notifications_enabled: boolean;
   first_day_of_week: number;
+  avatar_type: AvatarType;
 };
 
 export type UpdateUserProfileRequest = UserProfile;

--- a/frontend/types/svg.d.ts
+++ b/frontend/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: any;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- store the user avatar type in backend settings and expose it in profile and dashboard payloads
- add an Alembic migration plus shared constants/assets for the four avatar archetypes
- let users pick an avatar style in the profile screen and render the corresponding SVG on the dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e13fafa1248327a25fa14de009117e