### PR TITLE
Add STLLoader shim to unblock expo-three bundling

### DIFF
--- a/frontend/lib/shims/STLLoader.js
+++ b/frontend/lib/shims/STLLoader.js
@@ -1,0 +1,6 @@
+const THREE = require('three');
+const { STLLoader } = require('three/examples/jsm/loaders/STLLoader.js');
+
+THREE.STLLoader = STLLoader;
+
+module.exports = THREE.STLLoader;

--- a/frontend/metro.config.js
+++ b/frontend/metro.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const { getDefaultConfig } = require('expo/metro-config');
+const MetroResolver = require('metro-resolver');
+
+const config = getDefaultConfig(__dirname);
+const previousResolveRequest = config.resolver.resolveRequest;
+
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === 'three/examples/js/loaders/STLLoader') {
+    return {
+      type: 'sourceFile',
+      filePath: path.resolve(__dirname, 'lib/shims/STLLoader.js'),
+    };
+  }
+
+  if (previousResolveRequest) {
+    return previousResolveRequest(context, moduleName, platform);
+  }
+
+  return MetroResolver.resolve(context, moduleName, platform);
+};
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add a Metro resolver override that maps expo-three's legacy STLLoader import to a local shim
- provide a shim that re-exports the modern STLLoader from three/examples/jsm and attaches it to THREE for expo-three compatibility

## Testing
- npm run lint *(fails: unresolved modules reported by ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68e163a01c4c8327b7908c61c9851b80