### PR TITLE
Refactor rewards model schema

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -6,6 +6,7 @@ import enum
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any
 
 from sqlalchemy import (
     Boolean,
@@ -21,7 +22,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
 
 from .database import Base
@@ -432,13 +433,20 @@ class UserChallenge(Base):
     )
 
 
-class Reward(Base, TimestampMixin):
+class Reward(Base):
     __tablename__ = "rewards"
+    __table_args__ = (UniqueConstraint("key", name="uq_reward_key"),)
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    title: Mapped[str] = mapped_column(String(255), nullable=False)
-    cost_xp: Mapped[int] = mapped_column(Integer, nullable=False)
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    key: Mapped[str] = mapped_column(String(120), nullable=False)
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    condition_type: Mapped[str] = mapped_column(String(120), nullable=False)
+    condition_value: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    reward_data: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, default=dict
+    )
 
     user_rewards: Mapped[list["UserReward"]] = relationship(
         "UserReward", back_populates="reward"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -99,6 +99,12 @@ class User(Base, TimestampMixin):
     snapshots: Mapped[list["ProgressSnapshot"]] = relationship(
         "ProgressSnapshot", back_populates="user", cascade="all, delete-orphan"
     )
+    rewards: Mapped[list["UserReward"]] = relationship(
+        "UserReward", back_populates="user", cascade="all, delete-orphan"
+    )
+    cosmetics: Mapped[list["UserCosmetic"]] = relationship(
+        "UserCosmetic", back_populates="user", cascade="all, delete-orphan"
+    )
     user_settings: Mapped["UserSettings"] = relationship(
         "UserSettings",
         back_populates="user",
@@ -444,7 +450,7 @@ class Reward(Base):
     description: Mapped[str] = mapped_column(Text, nullable=False)
     condition_type: Mapped[str] = mapped_column(String(120), nullable=False)
     condition_value: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    reward_data: Mapped[dict[str, Any]] = mapped_column(
+    reward_data: Mapped[Any] = mapped_column(
         JSONB, nullable=False, default=dict
     )
 
@@ -456,21 +462,31 @@ class Reward(Base):
 class UserReward(Base):
     __tablename__ = "user_rewards"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
     user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
     )
     reward_id: Mapped[int] = mapped_column(
-        ForeignKey("rewards.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("rewards.id", ondelete="CASCADE"), primary_key=True
     )
-    acquired_at: Mapped[datetime] = mapped_column(
+    date_obtained: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    seen: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
-    user: Mapped[User] = relationship("User")
+    user: Mapped[User] = relationship("User", back_populates="rewards")
     reward: Mapped[Reward] = relationship("Reward", back_populates="user_rewards")
+
+
+class UserCosmetic(Base):
+    __tablename__ = "user_cosmetics"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    item_key: Mapped[str] = mapped_column(String(120), primary_key=True)
+    equipped: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    user: Mapped[User] = relationship("User", back_populates="cosmetics")
 
 
 class UserSettings(Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -260,6 +260,7 @@ class BadgeItem(BaseModel):
     title: str
     subtitle: str
     domain_id: Optional[int]
+    icon: Optional[str] = None
 
 
 class ProgressionResponse(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
@@ -46,6 +46,18 @@ class TaskLogCreate(BaseModel):
     source: str = Field(default="manual")
 
 
+class RewardRead(BaseModel):
+    id: int
+    key: str
+    type: str
+    name: str
+    description: str
+    reward_data: dict[str, Any] | None = None
+
+    class Config:
+        model_config = ConfigDict(from_attributes=True)
+
+
 class TaskLogRead(BaseModel):
     id: UUID
     user_id: UUID
@@ -58,6 +70,7 @@ class TaskLogRead(BaseModel):
     xp_awarded: int
     points_awarded: int
     source: str
+    unlocked_rewards: list[RewardRead] = Field(default_factory=list)
 
     class Config:
         model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/rewards.py
+++ b/backend/app/services/rewards.py
@@ -1,0 +1,217 @@
+"""Reward evaluation and unlocking helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Callable, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import Session
+
+from ..models import (
+    Domain,
+    ProgressSnapshot,
+    Reward,
+    SnapshotPeriod,
+    Streak,
+    TaskLog,
+    UserCosmetic,
+    UserDomainSetting,
+    UserReward,
+)
+
+
+@dataclass
+class RewardContext:
+    """Information used to decide if a reward should be unlocked."""
+
+    reward: Reward
+    user_id: UUID
+
+
+ConditionEvaluator = Callable[[RewardContext], bool]
+
+
+class RewardService:
+    """Encapsulate the reward unlocking flow."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self._evaluators: Dict[str, ConditionEvaluator] = {
+            "tasks_completed": self._check_tasks_completed,
+            "tasks_completed_category": self._check_tasks_completed_category,
+            "streak_days": self._check_streak_days,
+            "stats_balance": self._check_stats_balance,
+        }
+
+    def check_rewards(self, user_id: UUID) -> list[Reward]:
+        """Return the rewards unlocked after evaluating the current state."""
+
+        unlocked: list[Reward] = []
+        rewards = self.session.execute(select(Reward)).scalars().all()
+        for reward in rewards:
+            if self._has_reward(user_id, reward.id):
+                continue
+            context = RewardContext(reward=reward, user_id=user_id)
+            if self._evaluate_reward(context):
+                self._grant_reward(context)
+                unlocked.append(reward)
+        return unlocked
+
+    def _evaluate_reward(self, context: RewardContext) -> bool:
+        condition_type, _ = self._parse_condition(context.reward.condition_type)
+        evaluator = self._evaluators.get(condition_type)
+        if not evaluator:
+            return False
+        return evaluator(context)
+
+    def _parse_condition(self, condition_type: str) -> tuple[str, Optional[str]]:
+        if ":" in condition_type:
+            base, qualifier = condition_type.split(":", 1)
+            return base, qualifier
+        return condition_type, None
+
+    def _has_reward(self, user_id: UUID, reward_id: int) -> bool:
+        stmt: Select[Any] = select(UserReward).where(
+            UserReward.user_id == user_id,
+            UserReward.reward_id == reward_id,
+        )
+        return self.session.execute(stmt).first() is not None
+
+    def _grant_reward(self, context: RewardContext) -> None:
+        reward = context.reward
+        user_reward = UserReward(user_id=context.user_id, reward_id=reward.id)
+        self.session.add(user_reward)
+
+        if reward.type == "cosmetic":
+            item_key = self._resolve_cosmetic_key(reward.reward_data)
+            if item_key:
+                cosmetic_stmt = select(UserCosmetic).where(
+                    UserCosmetic.user_id == context.user_id,
+                    UserCosmetic.item_key == item_key,
+                )
+                cosmetic = self.session.execute(cosmetic_stmt).scalar_one_or_none()
+                if not cosmetic:
+                    self.session.add(
+                        UserCosmetic(user_id=context.user_id, item_key=item_key)
+                    )
+
+    def _resolve_cosmetic_key(self, payload: Any) -> Optional[str]:
+        if isinstance(payload, dict):
+            value = payload.get("item") or payload.get("item_key")
+            if isinstance(value, str):
+                return value
+        if isinstance(payload, str):
+            return payload
+        return None
+
+    def _check_tasks_completed(self, context: RewardContext) -> bool:
+        threshold = self._to_int(context.reward.condition_value)
+        if threshold is None:
+            return False
+        stmt = select(func.count()).select_from(TaskLog).where(
+            TaskLog.user_id == context.user_id
+        )
+        completed = self.session.execute(stmt).scalar_one()
+        return completed >= threshold
+
+    def _check_tasks_completed_category(self, context: RewardContext) -> bool:
+        threshold = self._to_int(context.reward.condition_value)
+        if threshold is None:
+            return False
+
+        _, qualifier = self._parse_condition(context.reward.condition_type)
+        domain_key: Optional[str] = None
+        if qualifier:
+            domain_key = qualifier
+        elif isinstance(context.reward.reward_data, dict):
+            candidate = context.reward.reward_data.get("domain") or context.reward.reward_data.get("domain_key")
+            if isinstance(candidate, str):
+                domain_key = candidate
+
+        if not domain_key:
+            return False
+
+        stmt = (
+            select(func.count())
+            .select_from(TaskLog)
+            .join(Domain, Domain.id == TaskLog.domain_id)
+            .where(TaskLog.user_id == context.user_id, Domain.key == domain_key)
+        )
+        completed = self.session.execute(stmt).scalar_one()
+        return completed >= threshold
+
+    def _check_streak_days(self, context: RewardContext) -> bool:
+        threshold = self._to_int(context.reward.condition_value)
+        if threshold is None:
+            return False
+
+        _, qualifier = self._parse_condition(context.reward.condition_type)
+        stmt = select(func.max(Streak.current_streak_days)).where(
+            Streak.user_id == context.user_id
+        )
+        if qualifier:
+            stmt = stmt.join(Domain, Domain.id == Streak.domain_id).where(Domain.key == qualifier)
+
+        current_streak = self.session.execute(stmt).scalar_one()
+        current_streak = current_streak or 0
+        return current_streak >= threshold
+
+    def _check_stats_balance(self, context: RewardContext) -> bool:
+        threshold = self._to_int(context.reward.condition_value)
+        if threshold is None:
+            return False
+
+        week_start = self._monday_start(date.today())
+        stmt = (
+            select(
+                Domain.id,
+                UserDomainSetting.weekly_target_points,
+                ProgressSnapshot.points_total,
+            )
+            .join(
+                UserDomainSetting,
+                (UserDomainSetting.domain_id == Domain.id)
+                & (UserDomainSetting.user_id == context.user_id),
+            )
+            .outerjoin(
+                ProgressSnapshot,
+                (ProgressSnapshot.user_id == context.user_id)
+                & (ProgressSnapshot.domain_id == Domain.id)
+                & (ProgressSnapshot.period == SnapshotPeriod.WEEK)
+                & (ProgressSnapshot.period_start_date == week_start),
+            )
+            .where(UserDomainSetting.is_enabled.is_(True))
+        )
+
+        rows = self.session.execute(stmt).all()
+        if not rows:
+            return False
+
+        for _, target_points, progress in rows:
+            if not target_points or target_points <= 0:
+                return False
+            percentage = (progress or 0) * 100 / target_points
+            if percentage < threshold:
+                return False
+        return True
+
+    def _to_int(self, value: Optional[str]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _monday_start(self, day: date) -> date:
+        return day - timedelta(days=day.weekday())
+
+
+def check_rewards(session: Session, user_id: UUID) -> list[Reward]:
+    """Evaluate and grant rewards for the given user."""
+
+    service = RewardService(session)
+    return service.check_rewards(user_id)

--- a/backend/app/services/task_logs.py
+++ b/backend/app/services/task_logs.py
@@ -23,6 +23,7 @@ from ..models import (
     XPEvent,
 )
 from ..schemas import TaskLogCreate
+from .rewards import check_rewards
 
 
 class TaskLogError(Exception):
@@ -275,5 +276,7 @@ def create_task_log(session: Session, payload: TaskLogCreate) -> TaskLog:
         points_awarded,
         occurred_at,
     )
+
+    check_rewards(session, payload.user_id)
 
     return task_log

--- a/backend/app/services/task_logs.py
+++ b/backend/app/services/task_logs.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from ..models import (
     Domain,
     ProgressSnapshot,
+    Reward,
     SnapshotPeriod,
     SourceType,
     Streak,
@@ -195,7 +196,7 @@ def monday_start(date_value: date) -> date:
     return date_value - timedelta(days=date_value.weekday())
 
 
-def create_task_log(session: Session, payload: TaskLogCreate) -> TaskLog:
+def create_task_log(session: Session, payload: TaskLogCreate) -> tuple[TaskLog, list[Reward]]:
     """Create a task log following MVP rules."""
 
     user = ensure_user_exists(session, payload.user_id)
@@ -277,6 +278,6 @@ def create_task_log(session: Session, payload: TaskLogCreate) -> TaskLog:
         occurred_at,
     )
 
-    check_rewards(session, payload.user_id)
+    unlocked_rewards = check_rewards(session, payload.user_id)
 
-    return task_log
+    return task_log, unlocked_rewards

--- a/backend/migrations/versions/c1bba60d4bb8_init_schema.py
+++ b/backend/migrations/versions/c1bba60d4bb8_init_schema.py
@@ -236,19 +236,29 @@ def upgrade() -> None:
     )
     op.create_table(
         'user_rewards',
-        sa.Column('id', sa.UUID(), nullable=False),
         sa.Column('user_id', sa.UUID(), nullable=False),
         sa.Column('reward_id', sa.Integer(), nullable=False),
         sa.Column(
-            'acquired_at',
+            'date_obtained',
             sa.DateTime(timezone=True),
             server_default=sa.text('now()'),
             nullable=False,
         ),
+        sa.Column('seen', sa.Boolean(), nullable=False, server_default=sa.text('false')),
         sa.ForeignKeyConstraint(['reward_id'], ['rewards.id'], ondelete='CASCADE'),
         sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
-        sa.PrimaryKeyConstraint('id'),
+        sa.PrimaryKeyConstraint('user_id', 'reward_id'),
     )
+    op.alter_column('user_rewards', 'seen', server_default=None)
+    op.create_table(
+        'user_cosmetics',
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('item_key', sa.String(length=120), nullable=False),
+        sa.Column('equipped', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('user_id', 'item_key'),
+    )
+    op.alter_column('user_cosmetics', 'equipped', server_default=None)
     op.create_table(
         'user_settings',
         sa.Column('user_id', sa.UUID(), nullable=False),
@@ -416,6 +426,7 @@ def downgrade() -> None:
     op.drop_index('ix_xp_events_user_occurred', table_name='xp_events')
     op.drop_table('xp_events')
     op.drop_table('user_settings')
+    op.drop_table('user_cosmetics')
     op.drop_table('user_rewards')
     op.drop_table('user_level')
     op.drop_table('user_domain_settings')

--- a/backend/migrations/versions/c1bba60d4bb8_init_schema.py
+++ b/backend/migrations/versions/c1bba60d4bb8_init_schema.py
@@ -8,6 +8,7 @@ Create Date: 2025-10-05 15:31:40.790090
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = 'c1bba60d4bb8'
@@ -41,22 +42,26 @@ def upgrade() -> None:
     op.create_table(
         'rewards',
         sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column('title', sa.String(length=255), nullable=False),
-        sa.Column('cost_xp', sa.Integer(), nullable=False),
-        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('key', sa.String(length=120), nullable=False),
+        sa.Column('type', sa.String(length=50), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('condition_type', sa.String(length=120), nullable=False),
+        sa.Column('condition_value', sa.String(length=255), nullable=True),
         sa.Column(
-            'created_at',
-            sa.DateTime(timezone=True),
-            server_default=sa.text('now()'),
+            'reward_data',
+            postgresql.JSONB(astext_type=sa.Text()),
             nullable=False,
-        ),
-        sa.Column(
-            'updated_at',
-            sa.DateTime(timezone=True),
-            server_default=sa.text('now()'),
-            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
         ),
         sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('key', name='uq_reward_key'),
+    )
+    op.alter_column(
+        'rewards',
+        'reward_data',
+        server_default=None,
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
     )
     op.create_table(
         'users',

--- a/frontend/app/progression.tsx
+++ b/frontend/app/progression.tsx
@@ -160,7 +160,7 @@ export default function ProgressionScreen() {
                   ) : (
                     badges.map((badge) => (
                       <View key={badge.id} style={styles.badgeRow}>
-                        <Text style={styles.badgeIcon}>🏆</Text>
+                        <Text style={styles.badgeIcon}>{badge.icon ?? "🏆"}</Text>
                         <View style={styles.badgeContent}>
                           <Text style={styles.badgeTitle}>{badge.title}</Text>
                           <Text style={styles.badgeSubtitle}>{badge.subtitle}</Text>

--- a/frontend/components/RewardUnlockModal.tsx
+++ b/frontend/components/RewardUnlockModal.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef } from "react";
+import { Animated, Modal, StyleSheet, Text, View } from "react-native";
+
+const DISPLAY_DURATION_MS = 2600;
+
+export type RewardUnlockModalProps = {
+  visible: boolean;
+  rewardName: string;
+  rewardTypeLabel: string;
+  icon?: string | null;
+  onHidden: () => void;
+};
+
+export default function RewardUnlockModal({
+  visible,
+  rewardName,
+  rewardTypeLabel,
+  icon,
+  onHidden,
+}: RewardUnlockModalProps) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const scale = useRef(new Animated.Value(0.85)).current;
+  const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!visible) {
+      if (hideTimeout.current) {
+        clearTimeout(hideTimeout.current);
+        hideTimeout.current = null;
+      }
+      return;
+    }
+
+    opacity.setValue(0);
+    scale.setValue(0.85);
+
+    Animated.parallel([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 220,
+        useNativeDriver: true,
+      }),
+      Animated.spring(scale, {
+        toValue: 1,
+        useNativeDriver: true,
+        friction: 7,
+        tension: 80,
+      }),
+    ]).start();
+
+    hideTimeout.current = setTimeout(() => {
+      Animated.parallel([
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: 220,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, {
+          toValue: 0.85,
+          duration: 220,
+          useNativeDriver: true,
+        }),
+      ]).start(() => {
+        hideTimeout.current = null;
+        onHidden();
+      });
+    }, DISPLAY_DURATION_MS);
+
+    return () => {
+      if (hideTimeout.current) {
+        clearTimeout(hideTimeout.current);
+        hideTimeout.current = null;
+      }
+    };
+  }, [opacity, scale, visible, onHidden]);
+
+  if (!visible) {
+    return null;
+  }
+
+  const displayIcon = icon && icon.trim().length > 0 ? icon : "🎉";
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" statusBarTranslucent>
+      <View style={styles.overlay}>
+        <Animated.View
+          style={[styles.container, { opacity, transform: [{ scale }] }]}
+        >
+          <Text style={styles.icon}>{displayIcon}</Text>
+          <Text style={styles.title}>Félicitations !</Text>
+          <Text style={styles.subtitle}>{rewardTypeLabel} débloqué 🎉</Text>
+          {rewardName ? <Text style={styles.rewardName}>{rewardName}</Text> : null}
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(15, 23, 42, 0.6)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  container: {
+    width: "100%",
+    maxWidth: 320,
+    borderRadius: 28,
+    paddingVertical: 28,
+    paddingHorizontal: 24,
+    backgroundColor: "rgba(15, 23, 42, 0.95)",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.35)",
+    shadowColor: "#0ea5e9",
+    shadowOpacity: 0.35,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 12 },
+    elevation: 12,
+  },
+  icon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  title: {
+    color: "#f8fafc",
+    fontSize: 22,
+    fontWeight: "700",
+  },
+  subtitle: {
+    color: "#cbd5f5",
+    fontSize: 16,
+    fontWeight: "500",
+    marginTop: 8,
+  },
+  rewardName: {
+    color: "#fbbf24",
+    fontSize: 20,
+    fontWeight: "700",
+    marginTop: 12,
+    textAlign: "center",
+  },
+});

--- a/frontend/context/HabitDataContext.tsx
+++ b/frontend/context/HabitDataContext.tsx
@@ -14,6 +14,7 @@ import type {
   CreateTaskRequest,
   DashboardResponse,
   ProgressionResponse,
+  RewardUnlock,
   TaskListResponse,
   UserSummary,
 } from "../types/api";
@@ -31,7 +32,7 @@ type HabitDataState = {
 type HabitDataContextValue = {
   state: HabitDataState;
   refresh: () => Promise<void>;
-  completeTask: (taskId: string) => Promise<void>;
+  completeTask: (taskId: string) => Promise<RewardUnlock[]>;
   createTask: (payload: CreateTaskRequest) => Promise<void>;
   enableTaskTemplate: (templateId: number) => Promise<void>;
   disableTaskTemplate: (templateId: number) => Promise<void>;
@@ -130,8 +131,9 @@ export function HabitDataProvider({ children }: { children: React.ReactNode }) {
       if (!state.user) {
         throw new Error("Utilisateur non chargé");
       }
-      await completeTaskLog(state.user.id, taskId);
+      const taskLog = await completeTaskLog(state.user.id, taskId);
       await refresh();
+      return taskLog.unlocked_rewards ?? [];
     },
     [refresh, state.user],
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   UserDomainSetting,
   UserProfile,
   UserSummary,
+  TaskLogResponse,
 } from "../types/api";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://127.0.0.1:8000";
@@ -197,7 +198,7 @@ export async function fetchProgression(
 export async function completeTaskLog(
   userId: string,
   userTaskId: string,
-): Promise<void> {
+): Promise<TaskLogResponse> {
   const response = await fetch(`${API_URL}/task-logs`, {
     method: "POST",
     headers: buildJsonHeaders(true),
@@ -211,6 +212,8 @@ export async function completeTaskLog(
     const message = await extractErrorMessage(response);
     throw new Error(message || "Impossible d'enregistrer la complétion de la tâche");
   }
+
+  return handleResponse<TaskLogResponse>(response);
 }
 
 export async function fetchUserTaskTemplates(

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -140,6 +140,7 @@ export type BadgeItem = {
   title: string;
   subtitle: string;
   domain_id: number | null;
+  icon: string | null;
 };
 
 export type ProgressionResponse = {

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -111,6 +111,30 @@ export type WeeklyStat = {
   weekly_xp: number;
 };
 
+export type RewardUnlock = {
+  id: number;
+  key: string;
+  type: string;
+  name: string;
+  description: string;
+  reward_data: Record<string, unknown> | null;
+};
+
+export type TaskLogResponse = {
+  id: string;
+  user_id: string;
+  user_task_id: string | null;
+  domain_id: number;
+  occurred_at: string;
+  quantity: string | null;
+  unit: string | null;
+  notes: string | null;
+  xp_awarded: number;
+  points_awarded: number;
+  source: string;
+  unlocked_rewards: RewardUnlock[];
+};
+
 export type BadgeItem = {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- refactor the SQLAlchemy `Reward` model to expose the new reward metadata columns and JSON payload
- align the initial Alembic migration with the refreshed rewards schema and unique key constraint

## Testing
- make check

------
https://chatgpt.com/codex/tasks/task_e_68e34467f5f483279c918871181a3dd5