### PR TITLE
Fix custom quest action input and update manage screen empty state

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -235,6 +235,10 @@ class TaskCreate(BaseModel):
     target_occurrences: int = Field(default=1, ge=1, le=100)
 
 
+class TaskUpdateRequest(TaskCreate):
+    pass
+
+
 class TaskTemplateItem(BaseModel):
     id: int
     title: str

--- a/frontend/app/quests/index.tsx
+++ b/frontend/app/quests/index.tsx
@@ -9,6 +9,7 @@ import {
   ListRenderItemInfo,
   Pressable,
   RefreshControl,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -611,6 +612,97 @@ export default function QuestsScreen() {
     );
   };
 
+  const renderHeader = useCallback(
+    () => (
+      <View style={styles.headerContainer}>
+        <View style={styles.headerTopRow}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => router.push("/")}
+            style={styles.backButton}
+          >
+            <Feather name="chevron-left" size={24} color="#f8fafc" />
+          </Pressable>
+          <Text style={styles.title}>Mes Quêtes</Text>
+          <View style={styles.headerActions}>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => router.push("/quests/catalogue")}
+              style={({ pressed }) => [
+                styles.catalogueButton,
+                pressed && styles.catalogueButtonPressed,
+              ]}
+            >
+              <Feather name="book-open" size={16} color="#f8fafc" />
+              <Text style={styles.catalogueButtonLabel}>Catalogue</Text>
+            </Pressable>
+          </View>
+        </View>
+        <View style={styles.personalSection}>
+          <View style={styles.personalHeaderRow}>
+            <Text style={styles.personalTitle}>Quêtes personnalisées</Text>
+            <Pressable
+              style={({ pressed }) => [
+                styles.personalManageButton,
+                pressed && styles.personalManageButtonPressed,
+              ]}
+              onPress={() => router.push("/quests/personalisation")}
+              accessibilityRole="button"
+            >
+              <Text style={styles.personalManageLabel}>Gérer</Text>
+              <Feather name="arrow-right" size={16} color="#cbd5f5" />
+            </Pressable>
+          </View>
+          <Text style={styles.personalEmptyLabel}>
+            {personalQuestItems.length === 0
+              ? "Ajoutez une quête personnalisée pour la retrouver ici."
+              : hiddenPersonalQuestItems.length > 0
+                ? `${personalQuestItems.length} quête(s) personnalisée(s) dont ${hiddenPersonalQuestItems.length} masquée(s) du global.`
+                : "Toutes vos quêtes personnalisées apparaissent dans la liste principale."}
+          </Text>
+        </View>
+      </View>
+    ),
+    [hiddenPersonalQuestItems.length, personalQuestItems.length, router],
+  );
+
+  const renderAddSection = useCallback(
+    () => (
+      <AddQuestSection
+        showAddTask={showAddTask}
+        isSubmitting={isSubmitting}
+        onStartAdd={handleStartAdd}
+        onCancel={handleCancelAdd}
+        onSubmit={handleCreateTaskSubmit}
+        onChangeTitle={handleChangeTitle}
+        newQuestTitle={newQuestTitle}
+        onSelectCategory={handleSelectCategory}
+        selectedCategory={selectedCategory}
+        occurrencesHelperLabel={occurrencesHelperLabel}
+        selectedFrequency={selectedFrequency}
+        onSelectFrequency={handleSelectFrequency}
+        occurrenceCount={occurrenceCount}
+        onChangeOccurrenceCount={handleChangeOccurrenceCount}
+      />
+    ),
+    [
+      handleCancelAdd,
+      handleChangeOccurrenceCount,
+      handleChangeTitle,
+      handleCreateTaskSubmit,
+      handleSelectCategory,
+      handleSelectFrequency,
+      handleStartAdd,
+      isSubmitting,
+      newQuestTitle,
+      occurrenceCount,
+      occurrencesHelperLabel,
+      selectedCategory,
+      selectedFrequency,
+      showAddTask,
+    ],
+  );
+
   return (
     <LinearGradient
       colors={["#111827", "#111827", "#1f2937"]}
@@ -620,87 +712,31 @@ export default function QuestsScreen() {
     >
       <SafeAreaView style={styles.safeArea}>
         <View style={styles.screen}>
-          <FlatList<TaskListItem>
-            data={displayedQuestItems}
-            keyExtractor={(item) => item.id}
-            renderItem={renderItem}
-            ListEmptyComponent={ListEmptyComponent}
-            ListFooterComponent={
-              <AddQuestSection
-                showAddTask={showAddTask}
-                isSubmitting={isSubmitting}
-                onStartAdd={handleStartAdd}
-                onCancel={handleCancelAdd}
-                onSubmit={handleCreateTaskSubmit}
-                onChangeTitle={handleChangeTitle}
-                newQuestTitle={newQuestTitle}
-                onSelectCategory={handleSelectCategory}
-                selectedCategory={selectedCategory}
-                occurrencesHelperLabel={occurrencesHelperLabel}
-                selectedFrequency={selectedFrequency}
-                onSelectFrequency={handleSelectFrequency}
-                occurrenceCount={occurrenceCount}
-                onChangeOccurrenceCount={handleChangeOccurrenceCount}
-              />
-            }
-            contentContainerStyle={styles.listContent}
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-            refreshControl={
-              <RefreshControl refreshing={isRefreshing} onRefresh={() => refresh()} tintColor="#818cf8" />
-            }
-            ListHeaderComponent={
-              <View style={styles.headerContainer}>
-                <View style={styles.headerTopRow}>
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={() => router.push("/")}
-                    style={styles.backButton}
-                  >
-                    <Feather name="chevron-left" size={24} color="#f8fafc" />
-                  </Pressable>
-                  <Text style={styles.title}>Mes Quêtes</Text>
-                  <View style={styles.headerActions}>
-
-                    <Pressable
-                      accessibilityRole="button"
-                      onPress={() => router.push("/quests/catalogue")}
-                      style={({ pressed }) => [
-                        styles.catalogueButton,
-                        pressed && styles.catalogueButtonPressed,
-                      ]}
-                    >
-                      <Feather name="book-open" size={16} color="#f8fafc" />
-                      <Text style={styles.catalogueButtonLabel}>Catalogue</Text>
-                    </Pressable>
-                  </View>
-                </View>
-                <View style={styles.personalSection}>
-                  <View style={styles.personalHeaderRow}>
-                    <Text style={styles.personalTitle}>Quêtes personnalisées</Text>
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.personalManageButton,
-                        pressed && styles.personalManageButtonPressed,
-                      ]}
-                      onPress={() => router.push("/quests/personalisation")}
-                      accessibilityRole="button"
-                    >
-                      <Text style={styles.personalManageLabel}>Gérer</Text>
-                      <Feather name="arrow-right" size={16} color="#cbd5f5" />
-                    </Pressable>
-                  </View>
-                  <Text style={styles.personalEmptyLabel}>
-                    {personalQuestItems.length === 0
-                      ? "Ajoutez une quête personnalisée pour la retrouver ici."
-                      : hiddenPersonalQuestItems.length > 0
-                        ? `${personalQuestItems.length} quête(s) personnalisée(s) dont ${hiddenPersonalQuestItems.length} masquée(s) du global.`
-                        : "Toutes vos quêtes personnalisées apparaissent dans la liste principale."}
-                  </Text>
-                </View>
-              </View>
-            }
-          />
+          {showAddTask ? (
+            <ScrollView
+              contentContainerStyle={styles.addOnlyContent}
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            >
+              {renderHeader()}
+              {renderAddSection()}
+            </ScrollView>
+          ) : (
+            <FlatList<TaskListItem>
+              data={displayedQuestItems}
+              keyExtractor={(item) => item.id}
+              renderItem={renderItem}
+              ListEmptyComponent={ListEmptyComponent}
+              ListFooterComponent={renderAddSection}
+              contentContainerStyle={styles.listContent}
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+              refreshControl={
+                <RefreshControl refreshing={isRefreshing} onRefresh={() => refresh()} tintColor="#818cf8" />
+              }
+              ListHeaderComponent={renderHeader}
+            />
+          )}
           <RewardUnlockModal
             visible={isRewardModalVisible && currentReward !== null}
             icon={rewardIcon}
@@ -726,6 +762,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   listContent: {
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 160,
+    gap: 16,
+    flexGrow: 1,
+  },
+  addOnlyContent: {
     paddingHorizontal: 24,
     paddingTop: 32,
     paddingBottom: 160,

--- a/frontend/app/quests/index.tsx
+++ b/frontend/app/quests/index.tsx
@@ -27,7 +27,7 @@ import {
   SCHEDULE_PERIOD_BY_FREQUENCY,
   PERIOD_HELPER_BY_SCHEDULE,
   buildDomainKeyOverrides,
-} from "./utils";
+} from "../../utils/quests";
 
 const REWARD_TYPE_LABELS: Record<string, string> = {
   badge: "Badge",

--- a/frontend/app/quests/personalisation.tsx
+++ b/frontend/app/quests/personalisation.tsx
@@ -7,38 +7,75 @@ import {
   Alert,
   FlatList,
   ListRenderItemInfo,
+  KeyboardAvoidingView,
+  Modal,
   Pressable,
   RefreshControl,
+  ScrollView,
   StyleSheet,
   Switch,
   Text,
+  TextInput,
   View,
+  Platform,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import BottomNav from "../../components/BottomNav";
 import { useHabitData } from "../../context/HabitDataContext";
-import type { TaskListItem } from "../../types/api";
+import { CATEGORIES, CATEGORY_OPTIONS, type CategoryKey } from "../../constants/categories";
+import type { TaskFrequency, TaskListItem } from "../../types/api";
+import {
+  FREQUENCY_CHOICES,
+  PERIOD_HELPER_BY_SCHEDULE,
+  SCHEDULE_PERIOD_BY_FREQUENCY,
+  buildDomainKeyOverrides,
+} from "./utils";
 
 export default function PersonalisationScreen() {
   const router = useRouter();
   const {
-    state: { tasks, status, errorMessage },
+    state: { tasks, status, errorMessage, dashboard },
     updateTaskVisibility,
+    updateTask,
+    deleteTask,
     refresh,
     isRefreshing,
   } = useHabitData();
 
+  const allTasks = useMemo(() => tasks?.tasks ?? [], [tasks]);
+
   const personalQuests = useMemo<TaskListItem[]>(
-    () => tasks?.tasks.filter((task) => task.is_custom) ?? [],
-    [tasks],
+    () => allTasks.filter((task) => task.is_custom),
+    [allTasks],
   );
 
+  const defaultCategory = useMemo(
+    () => (CATEGORY_OPTIONS[0] ?? "health") as CategoryKey,
+    [],
+  );
+
+  const domainKeyOverrides = useMemo(
+    () => buildDomainKeyOverrides(allTasks, dashboard ?? null),
+    [allTasks, dashboard],
+  );
+
+  const defaultCustomXp = 10;
+
   const [pendingTaskId, setPendingTaskId] = useState<string | null>(null);
+  const [deletingTaskId, setDeletingTaskId] = useState<string | null>(null);
+  const [isEditorVisible, setIsEditorVisible] = useState(false);
+  const [editingTask, setEditingTask] = useState<TaskListItem | null>(null);
+  const [editorTitle, setEditorTitle] = useState("");
+  const [editorCategory, setEditorCategory] = useState<CategoryKey>(defaultCategory);
+  const [editorFrequency, setEditorFrequency] = useState<TaskFrequency>("daily");
+  const [editorOccurrences, setEditorOccurrences] = useState("1");
+  const [editorXp, setEditorXp] = useState(defaultCustomXp);
+  const [isSaving, setIsSaving] = useState(false);
 
   const handleToggle = useCallback(
     async (task: TaskListItem, nextValue: boolean) => {
-      if (pendingTaskId) {
+      if (pendingTaskId || deletingTaskId) {
         return;
       }
 
@@ -55,13 +92,247 @@ export default function PersonalisationScreen() {
         setPendingTaskId(null);
       }
     },
-    [pendingTaskId, updateTaskVisibility],
+    [deletingTaskId, pendingTaskId, updateTaskVisibility],
   );
+
+  const normalizeText = useCallback((value: string | null | undefined) => {
+    if (!value) {
+      return "";
+    }
+    return value
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .trim();
+  }, []);
+
+  const resolveCategoryForTask = useCallback(
+    (task: TaskListItem): CategoryKey => {
+      for (const [categoryKey, domainKey] of domainKeyOverrides.entries()) {
+        if (domainKey === task.domain_key) {
+          return categoryKey;
+        }
+      }
+
+      if (CATEGORY_OPTIONS.includes(task.domain_key as CategoryKey)) {
+        return task.domain_key as CategoryKey;
+      }
+
+      const normalizedDomainName = normalizeText(task.domain_name);
+      if (normalizedDomainName) {
+        const match = CATEGORY_OPTIONS.find((categoryKey) => {
+          const category = CATEGORIES[categoryKey];
+          return normalizeText(category.label) === normalizedDomainName;
+        });
+        if (match) {
+          return match;
+        }
+      }
+
+      return defaultCategory;
+    },
+    [defaultCategory, domainKeyOverrides, normalizeText],
+  );
+
+  const resetEditor = useCallback(() => {
+    setEditingTask(null);
+    setEditorTitle("");
+    setEditorCategory(defaultCategory);
+    setEditorFrequency("daily");
+    setEditorOccurrences("1");
+    setEditorXp(defaultCustomXp);
+  }, [defaultCategory, defaultCustomXp]);
+
+  const handleCloseEditor = useCallback(() => {
+    if (isSaving) {
+      return;
+    }
+    setIsEditorVisible(false);
+    resetEditor();
+  }, [isSaving, resetEditor]);
+
+  const handleEditPress = useCallback(
+    (task: TaskListItem) => {
+      const category = resolveCategoryForTask(task);
+      setEditingTask(task);
+      setEditorTitle(task.title);
+      setEditorCategory(category);
+      setEditorFrequency(task.frequency_type as TaskFrequency);
+      setEditorOccurrences(String(task.target_occurrences));
+      setEditorXp(task.xp ?? defaultCustomXp);
+      setIsEditorVisible(true);
+    },
+    [defaultCustomXp, resolveCategoryForTask],
+  );
+
+  const handleEditorTitleChange = useCallback((value: string) => {
+    setEditorTitle(value);
+  }, []);
+
+  const handleEditorSelectCategory = useCallback((category: CategoryKey) => {
+    setEditorCategory(category);
+  }, []);
+
+  const handleEditorSelectFrequency = useCallback((value: TaskFrequency) => {
+    setEditorFrequency(value);
+    setEditorOccurrences((previous) => {
+      const parsed = Number.parseInt(previous, 10);
+      if (Number.isNaN(parsed) || parsed < 1) {
+        return "1";
+      }
+      return previous;
+    });
+  }, []);
+
+  const handleEditorOccurrencesChange = useCallback((value: string) => {
+    setEditorOccurrences(value.replace(/[^0-9]/g, ""));
+  }, []);
+
+  const editorOccurrencesHelper = useMemo(() => {
+    const period = SCHEDULE_PERIOD_BY_FREQUENCY[editorFrequency];
+    return PERIOD_HELPER_BY_SCHEDULE[period] ?? "par période";
+  }, [editorFrequency]);
+
+  const handleSaveEditor = useCallback(async () => {
+    if (!editingTask) {
+      return;
+    }
+
+    const title = editorTitle.trim();
+    if (!title) {
+      Alert.alert("Titre requis", "Veuillez saisir un titre pour votre quête.");
+      return;
+    }
+
+    const parsedOccurrences = Number.parseInt(editorOccurrences, 10);
+    if (Number.isNaN(parsedOccurrences) || parsedOccurrences < 1) {
+      Alert.alert(
+        "Fréquence invalide",
+        "Veuillez indiquer un nombre de répétitions supérieur ou égal à 1.",
+      );
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      const frequency = editorFrequency;
+      const domainKeyToSend = domainKeyOverrides.get(editorCategory) ?? editorCategory;
+      await updateTask(editingTask.id, {
+        title,
+        domain_key: domainKeyToSend,
+        xp: editorXp,
+        frequency_type: frequency,
+        schedule_period: SCHEDULE_PERIOD_BY_FREQUENCY[frequency],
+        schedule_interval: 1,
+        target_occurrences: parsedOccurrences,
+      });
+      setIsEditorVisible(false);
+      resetEditor();
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Impossible de mettre à jour cette quête.";
+      Alert.alert("Erreur", message);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    domainKeyOverrides,
+    editorCategory,
+    editorFrequency,
+    editorOccurrences,
+    editorTitle,
+    editorXp,
+    editingTask,
+    resetEditor,
+    updateTask,
+  ]);
+
+  const confirmDeleteTask = useCallback(
+    async (taskId: string) => {
+      try {
+        setDeletingTaskId(taskId);
+        await deleteTask(taskId);
+        if (editingTask && editingTask.id === taskId) {
+          setIsEditorVisible(false);
+          resetEditor();
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Impossible de supprimer cette quête.";
+        Alert.alert("Erreur", message);
+      } finally {
+        setDeletingTaskId(null);
+      }
+    },
+    [deleteTask, editingTask, resetEditor],
+  );
+
+  const handleDeletePress = useCallback(
+    (task: TaskListItem) => {
+      if (deletingTaskId) {
+        return;
+      }
+
+      Alert.alert(
+        "Supprimer cette quête ?",
+        `Voulez-vous supprimer la quête "${task.title}" ?`,
+        [
+          { text: "Annuler", style: "cancel" },
+          {
+            text: "Supprimer",
+            style: "destructive",
+            onPress: () => {
+              void confirmDeleteTask(task.id);
+            },
+          },
+        ],
+      );
+    },
+    [confirmDeleteTask, deletingTaskId],
+  );
+
+  const renderAddQuestButton = useCallback(
+    () => (
+      <Pressable
+        style={({ pressed }) => [
+          styles.addQuestButton,
+          pressed && styles.addQuestButtonPressed,
+        ]}
+        onPress={() => router.push("/quests")}
+        accessibilityRole="button"
+        accessibilityLabel="Ajouter une quête personnalisée"
+      >
+        <LinearGradient
+          colors={["#7c3aed", "#ec4899"]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.addQuestButtonGradient}
+        >
+          <Feather name="plus" size={16} color="#f8fafc" />
+          <Text style={styles.addQuestButtonLabel}>Ajouter une quête personnalisée</Text>
+        </LinearGradient>
+      </Pressable>
+    ),
+    [router],
+  );
+
+  const listHeaderComponent = useMemo(() => {
+    if (personalQuests.length === 0) {
+      return null;
+    }
+    return <View style={styles.listHeader}>{renderAddQuestButton()}</View>;
+  }, [personalQuests, renderAddQuestButton]);
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<TaskListItem>) => {
       const icon = item.icon ?? "⭐";
       const isBusy = pendingTaskId === item.id;
+      const isDeleting = deletingTaskId === item.id;
+      const isActionDisabled = isBusy || isDeleting || isSaving;
       return (
         <View style={styles.questRow}>
           <View style={styles.questInfo}>
@@ -73,20 +344,59 @@ export default function PersonalisationScreen() {
               </Text>
             </View>
           </View>
-          {isBusy ? (
-            <ActivityIndicator size="small" color="#818cf8" />
-          ) : (
-            <Switch
-              value={item.show_in_global}
-              onValueChange={(value) => handleToggle(item, value)}
-              trackColor={{ false: "#475569", true: "#7c3aed" }}
-              thumbColor={item.show_in_global ? "#f8fafc" : "#cbd5f5"}
-            />
-          )}
+          <View style={styles.questControls}>
+            {isDeleting ? (
+              <ActivityIndicator
+                size="small"
+                color="#f87171"
+                style={styles.questActionSpinner}
+              />
+            ) : (
+              <View style={styles.questActionButtons}>
+                <Pressable
+                  onPress={() => handleEditPress(item)}
+                  style={({ pressed }) => [
+                    styles.questActionButton,
+                    pressed && styles.questActionButtonPressed,
+                    isActionDisabled && styles.questActionButtonDisabled,
+                  ]}
+                  disabled={isActionDisabled}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Modifier ${item.title}`}
+                >
+                  <Feather name="edit-2" size={16} color="#f8fafc" />
+                </Pressable>
+                <Pressable
+                  onPress={() => handleDeletePress(item)}
+                  style={({ pressed }) => [
+                    styles.questActionButton,
+                    pressed && styles.questActionButtonPressed,
+                    isActionDisabled && styles.questActionButtonDisabled,
+                  ]}
+                  disabled={isActionDisabled}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Supprimer ${item.title}`}
+                >
+                  <Feather name="trash-2" size={16} color="#f87171" />
+                </Pressable>
+              </View>
+            )}
+            {isBusy ? (
+              <ActivityIndicator size="small" color="#818cf8" />
+            ) : (
+              <Switch
+                value={item.show_in_global}
+                onValueChange={(value) => handleToggle(item, value)}
+                trackColor={{ false: "#475569", true: "#7c3aed" }}
+                thumbColor={item.show_in_global ? "#f8fafc" : "#cbd5f5"}
+                disabled={isDeleting || isSaving}
+              />
+            )}
+          </View>
         </View>
       );
     },
-    [handleToggle, pendingTaskId],
+    [deletingTaskId, handleDeletePress, handleEditPress, handleToggle, isSaving, pendingTaskId],
   );
 
   const listEmptyComponent = () => {
@@ -117,12 +427,7 @@ export default function PersonalisationScreen() {
         <Text style={styles.emptyStateLabel}>
           Il n’y a pas de quêtes personnalisées.
         </Text>
-        <Pressable
-          style={styles.retryButton}
-          onPress={() => router.replace("/quests")}
-        >
-          <Text style={styles.retryButtonLabel}>Ajouter une quête</Text>
-        </Pressable>
+        {renderAddQuestButton()}
       </View>
     );
   };
@@ -156,6 +461,7 @@ export default function PersonalisationScreen() {
             keyExtractor={(item) => item.id}
             renderItem={renderItem}
             ListEmptyComponent={listEmptyComponent}
+            ListHeaderComponent={listHeaderComponent}
             contentContainerStyle={styles.listContent}
             refreshControl={
               <RefreshControl
@@ -167,6 +473,165 @@ export default function PersonalisationScreen() {
             ItemSeparatorComponent={() => <View style={styles.separator} />}
             showsVerticalScrollIndicator={false}
           />
+          <Modal
+            visible={isEditorVisible}
+            transparent
+            animationType="slide"
+            onRequestClose={handleCloseEditor}
+          >
+            <View style={styles.modalOverlay}>
+              <KeyboardAvoidingView
+                behavior={Platform.OS === "ios" ? "padding" : undefined}
+                style={styles.modalContainer}
+              >
+                <View style={styles.modalContent}>
+                  <View style={styles.modalHeader}>
+                    <Text style={styles.modalTitle}>Modifier la quête</Text>
+                    <Pressable
+                      onPress={handleCloseEditor}
+                      disabled={isSaving}
+                      accessibilityRole="button"
+                      accessibilityLabel="Fermer la modification"
+                      style={({ pressed }) => [
+                        styles.modalCloseButton,
+                        pressed && styles.modalCloseButtonPressed,
+                        isSaving && styles.modalCloseButtonDisabled,
+                      ]}
+                    >
+                      <Feather name="x" size={18} color="#f8fafc" />
+                    </Pressable>
+                  </View>
+                  <ScrollView
+                    contentContainerStyle={styles.modalScrollContent}
+                    showsVerticalScrollIndicator={false}
+                  >
+                    <Text style={styles.modalSectionLabel}>Catégorie</Text>
+                    <View style={styles.modalCategoryOptions}>
+                      {CATEGORY_OPTIONS.map((categoryKey) => {
+                        const category = CATEGORIES[categoryKey];
+                        const isSelected = editorCategory === categoryKey;
+                        return (
+                          <Pressable
+                            key={categoryKey}
+                            style={({ pressed }) => [
+                              styles.modalCategoryOption,
+                              isSelected && styles.modalCategoryOptionSelected,
+                              pressed && styles.modalCategoryOptionPressed,
+                            ]}
+                            onPress={() => handleEditorSelectCategory(categoryKey)}
+                            disabled={isSaving}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Sélectionner ${category.label}`}
+                          >
+                            <Text
+                              style={[
+                                styles.modalCategoryOptionLabel,
+                                isSelected && styles.modalCategoryOptionLabelSelected,
+                              ]}
+                            >
+                              {category.icon} {category.label}
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+
+                    <Text style={styles.modalSectionLabel}>Action</Text>
+                    <TextInput
+                      style={styles.modalInput}
+                      placeholder="Ex: Méditer 10 minutes"
+                      placeholderTextColor="#64748b"
+                      value={editorTitle}
+                      onChangeText={handleEditorTitleChange}
+                      editable={!isSaving}
+                    />
+
+                    <Text style={styles.modalSectionLabel}>Fréquence</Text>
+                    <View style={styles.modalFrequencyOptions}>
+                      {FREQUENCY_CHOICES.map((option) => {
+                        const isSelected = editorFrequency === option.value;
+                        return (
+                          <Pressable
+                            key={option.value}
+                            style={({ pressed }) => [
+                              styles.modalFrequencyOption,
+                              isSelected && styles.modalFrequencyOptionSelected,
+                              pressed && styles.modalFrequencyOptionPressed,
+                            ]}
+                            onPress={() => handleEditorSelectFrequency(option.value)}
+                            disabled={isSaving}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Utiliser la fréquence ${option.label}`}
+                          >
+                            <Text
+                              style={[
+                                styles.modalFrequencyLabel,
+                                isSelected && styles.modalFrequencyLabelSelected,
+                              ]}
+                            >
+                              {option.label}
+                            </Text>
+                            <Text style={styles.modalFrequencyHelper}>
+                              {option.periodLabel}
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+
+                    <Text style={styles.modalSectionLabel}>Objectif</Text>
+                    <Text style={styles.modalHelperText}>
+                      Nombre de fois {editorOccurrencesHelper}
+                    </Text>
+                    <TextInput
+                      style={styles.modalInput}
+                      placeholder={editorFrequency === "weekly" ? "2" : "1"}
+                      placeholderTextColor="#64748b"
+                      value={editorOccurrences}
+                      onChangeText={handleEditorOccurrencesChange}
+                      keyboardType="number-pad"
+                      maxLength={3}
+                      editable={!isSaving}
+                    />
+                  </ScrollView>
+                  <View style={styles.modalActions}>
+                    <Pressable
+                      onPress={handleCloseEditor}
+                      disabled={isSaving}
+                      style={[
+                        styles.modalSecondaryButton,
+                        isSaving && styles.modalSecondaryButtonDisabled,
+                      ]}
+                    >
+                      <Text style={styles.modalSecondaryButtonLabel}>Annuler</Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={handleSaveEditor}
+                      disabled={isSaving}
+                      style={({ pressed }) => [
+                        styles.modalPrimaryButton,
+                        pressed && styles.modalPrimaryButtonPressed,
+                        isSaving && styles.modalPrimaryButtonDisabled,
+                      ]}
+                    >
+                      <LinearGradient
+                        colors={["#7c3aed", "#ec4899"]}
+                        start={{ x: 0, y: 0 }}
+                        end={{ x: 1, y: 1 }}
+                        style={styles.modalPrimaryGradient}
+                      >
+                        {isSaving ? (
+                          <ActivityIndicator size="small" color="#f8fafc" />
+                        ) : (
+                          <Text style={styles.modalPrimaryButtonLabel}>Enregistrer</Text>
+                        )}
+                      </LinearGradient>
+                    </Pressable>
+                  </View>
+                </View>
+              </KeyboardAvoidingView>
+            </View>
+          </Modal>
           <BottomNav />
         </View>
       </SafeAreaView>
@@ -222,8 +687,33 @@ const styles = StyleSheet.create({
   },
   listContent: {
     flexGrow: 1,
-    paddingBottom: 40,
+    paddingBottom: 160,
     gap: 12,
+  },
+  listHeader: {
+    marginBottom: 12,
+  },
+  addQuestButton: {
+    borderRadius: 16,
+    overflow: "hidden",
+    alignSelf: "center",
+  },
+  addQuestButtonPressed: {
+    opacity: 0.9,
+  },
+  addQuestButtonGradient: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    minWidth: 220,
+  },
+  addQuestButtonLabel: {
+    color: "#f8fafc",
+    fontWeight: "600",
+    fontSize: 14,
   },
   questRow: {
     flexDirection: "row",
@@ -258,6 +748,33 @@ const styles = StyleSheet.create({
     color: "#94a3b8",
     fontSize: 12,
   },
+  questControls: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  questActionButtons: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  questActionButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 12,
+    backgroundColor: "rgba(79, 70, 229, 0.3)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  questActionButtonPressed: {
+    opacity: 0.85,
+  },
+  questActionButtonDisabled: {
+    opacity: 0.5,
+  },
+  questActionSpinner: {
+    marginRight: 8,
+  },
   separator: {
     height: 12,
   },
@@ -281,5 +798,171 @@ const styles = StyleSheet.create({
   retryButtonLabel: {
     color: "#f8fafc",
     fontWeight: "600",
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(15, 23, 42, 0.85)",
+    padding: 24,
+    justifyContent: "center",
+  },
+  modalContainer: {
+    flex: 1,
+    justifyContent: "center",
+  },
+  modalContent: {
+    backgroundColor: "rgba(30, 41, 59, 0.98)",
+    borderRadius: 24,
+    padding: 20,
+    gap: 16,
+    maxHeight: 620,
+  },
+  modalHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  modalTitle: {
+    color: "#f8fafc",
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  modalCloseButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 12,
+    backgroundColor: "rgba(71, 85, 105, 0.4)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalCloseButtonPressed: {
+    opacity: 0.8,
+  },
+  modalCloseButtonDisabled: {
+    opacity: 0.4,
+  },
+  modalScrollContent: {
+    gap: 16,
+    paddingBottom: 8,
+  },
+  modalSectionLabel: {
+    color: "#f8fafc",
+    fontWeight: "600",
+    fontSize: 14,
+  },
+  modalCategoryOptions: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  modalCategoryOption: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.4)",
+    backgroundColor: "rgba(15, 23, 42, 0.6)",
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  modalCategoryOptionSelected: {
+    borderColor: "rgba(129, 140, 248, 0.9)",
+    backgroundColor: "rgba(129, 140, 248, 0.25)",
+  },
+  modalCategoryOptionPressed: {
+    opacity: 0.85,
+  },
+  modalCategoryOptionLabel: {
+    color: "#cbd5f5",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  modalCategoryOptionLabelSelected: {
+    color: "#f8fafc",
+  },
+  modalInput: {
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.4)",
+    backgroundColor: "rgba(15, 23, 42, 0.7)",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    color: "#f8fafc",
+    fontSize: 14,
+  },
+  modalFrequencyOptions: {
+    gap: 8,
+  },
+  modalFrequencyOption: {
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.4)",
+    backgroundColor: "rgba(15, 23, 42, 0.6)",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 4,
+  },
+  modalFrequencyOptionSelected: {
+    borderColor: "rgba(236, 72, 153, 0.9)",
+    backgroundColor: "rgba(236, 72, 153, 0.25)",
+  },
+  modalFrequencyOptionPressed: {
+    opacity: 0.85,
+  },
+  modalFrequencyLabel: {
+    color: "#cbd5f5",
+    fontWeight: "600",
+    fontSize: 14,
+  },
+  modalFrequencyLabelSelected: {
+    color: "#f8fafc",
+  },
+  modalFrequencyHelper: {
+    color: "#94a3b8",
+    fontSize: 12,
+  },
+  modalHelperText: {
+    color: "#94a3b8",
+    fontSize: 12,
+  },
+  modalActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  modalSecondaryButton: {
+    flex: 1,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(148, 163, 184, 0.4)",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 12,
+  },
+  modalSecondaryButtonDisabled: {
+    opacity: 0.5,
+  },
+  modalSecondaryButtonLabel: {
+    color: "#f8fafc",
+    fontWeight: "600",
+    fontSize: 14,
+  },
+  modalPrimaryButton: {
+    flex: 1,
+    borderRadius: 14,
+    overflow: "hidden",
+  },
+  modalPrimaryButtonPressed: {
+    opacity: 0.9,
+  },
+  modalPrimaryButtonDisabled: {
+    opacity: 0.7,
+  },
+  modalPrimaryGradient: {
+    paddingVertical: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalPrimaryButtonLabel: {
+    color: "#f8fafc",
+    fontWeight: "700",
+    fontSize: 14,
   },
 });

--- a/frontend/app/quests/personalisation.tsx
+++ b/frontend/app/quests/personalisation.tsx
@@ -30,7 +30,7 @@ import {
   PERIOD_HELPER_BY_SCHEDULE,
   SCHEDULE_PERIOD_BY_FREQUENCY,
   buildDomainKeyOverrides,
-} from "./utils";
+} from "../../utils/quests";
 
 export default function PersonalisationScreen() {
   const router = useRouter();

--- a/frontend/app/quests/personalisation.tsx
+++ b/frontend/app/quests/personalisation.tsx
@@ -115,13 +115,13 @@ export default function PersonalisationScreen() {
     return (
       <View style={styles.emptyState}>
         <Text style={styles.emptyStateLabel}>
-          Vous n’avez pas encore créé de quête personnalisée.
+          Il n’y a pas de quêtes personnalisées.
         </Text>
         <Pressable
           style={styles.retryButton}
           onPress={() => router.replace("/quests")}
         >
-          <Text style={styles.retryButtonLabel}>Créer une quête</Text>
+          <Text style={styles.retryButtonLabel}>Ajouter une quête</Text>
         </Pressable>
       </View>
     );

--- a/frontend/app/quests/utils.ts
+++ b/frontend/app/quests/utils.ts
@@ -1,0 +1,72 @@
+import type { SnapshotPeriod, TaskFrequency, TaskListItem, DashboardResponse } from "../../types/api";
+import { CATEGORY_OPTIONS, CATEGORIES, type CategoryKey } from "../../constants/categories";
+
+export const FREQUENCY_CHOICES: { value: TaskFrequency; label: string; periodLabel: string }[] = [
+  { value: "daily", label: "Quotidienne", periodLabel: "aujourd’hui" },
+  { value: "weekly", label: "Hebdomadaire", periodLabel: "cette semaine" },
+  { value: "monthly", label: "Mensuelle", periodLabel: "ce mois-ci" },
+];
+
+export const SCHEDULE_PERIOD_BY_FREQUENCY: Record<TaskFrequency, SnapshotPeriod> = {
+  daily: "day",
+  weekly: "week",
+  monthly: "month",
+};
+
+export const PERIOD_HELPER_BY_SCHEDULE: Record<SnapshotPeriod, string> = {
+  day: "par jour",
+  week: "par semaine",
+  month: "par mois",
+};
+
+const normalizeText = (value: string | null | undefined) =>
+  value
+    ? value
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .trim()
+    : "";
+
+export function buildDomainKeyOverrides(
+  tasks: TaskListItem[],
+  dashboard: DashboardResponse | null,
+): Map<CategoryKey, string> {
+  const overrides = new Map<CategoryKey, string>();
+
+  const candidates: { key: string; name: string }[] = [];
+
+  if (dashboard) {
+    for (const stat of dashboard.domain_stats) {
+      candidates.push({ key: stat.domain_key, name: stat.domain_name });
+    }
+  }
+
+  for (const task of tasks) {
+    candidates.push({ key: task.domain_key, name: task.domain_name });
+  }
+
+  if (candidates.length === 0) {
+    return overrides;
+  }
+
+  for (const categoryKey of CATEGORY_OPTIONS) {
+    const category = CATEGORIES[categoryKey];
+    const normalizedKey = normalizeText(categoryKey);
+    const normalizedLabel = normalizeText(category.label);
+
+    const match = candidates.find((candidate) => {
+      const normalizedCandidateKey = normalizeText(candidate.key);
+      const normalizedCandidateName = normalizeText(candidate.name);
+      return (
+        normalizedCandidateKey === normalizedKey || normalizedCandidateName === normalizedLabel
+      );
+    });
+
+    if (match) {
+      overrides.set(categoryKey, match.key);
+    }
+  }
+
+  return overrides;
+}

--- a/frontend/context/HabitDataContext.tsx
+++ b/frontend/context/HabitDataContext.tsx
@@ -3,6 +3,8 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import {
   completeTaskLog,
   createTask as createTaskApi,
+  updateTask as updateTaskApi,
+  deleteTask as deleteTaskApi,
   enableUserTaskTemplate,
   disableUserTaskTemplate,
   fetchDashboard,
@@ -16,6 +18,7 @@ import type {
   ProgressionResponse,
   RewardUnlock,
   TaskListResponse,
+  UpdateTaskRequest,
   UserSummary,
 } from "../types/api";
 import { useAuth } from "./AuthContext";
@@ -34,6 +37,8 @@ type HabitDataContextValue = {
   refresh: () => Promise<void>;
   completeTask: (taskId: string) => Promise<RewardUnlock[]>;
   createTask: (payload: CreateTaskRequest) => Promise<void>;
+  updateTask: (taskId: string, payload: UpdateTaskRequest) => Promise<void>;
+  deleteTask: (taskId: string) => Promise<void>;
   enableTaskTemplate: (templateId: number) => Promise<void>;
   disableTaskTemplate: (templateId: number) => Promise<void>;
   updateTaskVisibility: (taskId: string, showInGlobal: boolean) => Promise<void>;
@@ -149,6 +154,28 @@ export function HabitDataProvider({ children }: { children: React.ReactNode }) {
     [refresh, state.user],
   );
 
+  const updateTask = useCallback(
+    async (taskId: string, payload: UpdateTaskRequest) => {
+      if (!state.user) {
+        throw new Error("Utilisateur non chargé");
+      }
+      await updateTaskApi(state.user.id, taskId, payload);
+      await refresh();
+    },
+    [refresh, state.user],
+  );
+
+  const deleteTask = useCallback(
+    async (taskId: string) => {
+      if (!state.user) {
+        throw new Error("Utilisateur non chargé");
+      }
+      await deleteTaskApi(state.user.id, taskId);
+      await refresh();
+    },
+    [refresh, state.user],
+  );
+
   const enableTaskTemplate = useCallback(
     async (templateId: number) => {
       if (!state.user) {
@@ -190,6 +217,8 @@ export function HabitDataProvider({ children }: { children: React.ReactNode }) {
       refresh,
       completeTask,
       createTask,
+      updateTask,
+      deleteTask,
       enableTaskTemplate,
       disableTaskTemplate,
       updateTaskVisibility,
@@ -200,6 +229,8 @@ export function HabitDataProvider({ children }: { children: React.ReactNode }) {
       refresh,
       completeTask,
       createTask,
+      updateTask,
+      deleteTask,
       enableTaskTemplate,
       disableTaskTemplate,
       updateTaskVisibility,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   UserProfile,
   UserSummary,
   TaskLogResponse,
+  UpdateTaskRequest,
 } from "../types/api";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://127.0.0.1:8000";
@@ -173,6 +174,19 @@ export async function createTask(
   return handleResponse<TaskListItem>(response);
 }
 
+export async function updateTask(
+  userId: string,
+  taskId: string,
+  payload: UpdateTaskRequest,
+): Promise<TaskListItem> {
+  const response = await fetch(`${API_URL}/users/${userId}/tasks/${taskId}`, {
+    method: "PATCH",
+    headers: buildJsonHeaders(true),
+    body: JSON.stringify(payload),
+  });
+  return handleResponse<TaskListItem>(response);
+}
+
 export async function updateTaskVisibility(
   userId: string,
   taskId: string,
@@ -184,6 +198,17 @@ export async function updateTaskVisibility(
     body: JSON.stringify(payload),
   });
   return handleResponse<TaskListItem>(response);
+}
+
+export async function deleteTask(userId: string, taskId: string): Promise<void> {
+  const response = await fetch(`${API_URL}/users/${userId}/tasks/${taskId}`, {
+    method: "DELETE",
+    headers: buildJsonHeaders(),
+  });
+
+  if (!response.ok && response.status !== 204) {
+    throw new Error(await extractErrorMessage(response));
+  }
 }
 
 export async function fetchProgression(

--- a/frontend/types/api.ts
+++ b/frontend/types/api.ts
@@ -74,6 +74,16 @@ export type CreateTaskRequest = {
   target_occurrences: number;
 };
 
+export type UpdateTaskRequest = {
+  title: string;
+  domain_key: string;
+  xp: number;
+  frequency_type: TaskFrequency;
+  schedule_period: SnapshotPeriod;
+  schedule_interval: number;
+  target_occurrences: number;
+};
+
 export type UpdateTaskVisibilityRequest = {
   show_in_global: boolean;
 };

--- a/frontend/utils/quests.ts
+++ b/frontend/utils/quests.ts
@@ -1,5 +1,5 @@
-import type { SnapshotPeriod, TaskFrequency, TaskListItem, DashboardResponse } from "../../types/api";
-import { CATEGORY_OPTIONS, CATEGORIES, type CategoryKey } from "../../constants/categories";
+import type { SnapshotPeriod, TaskFrequency, TaskListItem, DashboardResponse } from "../types/api";
+import { CATEGORY_OPTIONS, CATEGORIES, type CategoryKey } from "../constants/categories";
 
 export const FREQUENCY_CHOICES: { value: TaskFrequency; label: string; periodLabel: string }[] = [
   { value: "daily", label: "Quotidienne", periodLabel: "aujourd’hui" },


### PR DESCRIPTION
## Summary
- refactor the add quest footer into a dedicated component to avoid remounting the action input
- keep the add quest form stateful with memoized callbacks and ensure typing is uninterrupted
- update the personalisation screen empty state message and CTA to surface the “add quest” flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4b9967dc083279965a689fb72ced0